### PR TITLE
Squash a -Wformat-security warning (ml).

### DIFF
--- a/Programs/async_io.c
+++ b/Programs/async_io.c
@@ -193,7 +193,7 @@ static void
 logOperation (const OperationEntry *operation, void *callback) {
   logSymbol(LOG_CATEGORY(ASYNC_EVENTS),
             callback,
-            operation->function->methods->functionName);
+            "%s", operation->function->methods->functionName);
 }
 
 #ifdef __MINGW32__


### PR DESCRIPTION
-Wformat-security warns about this call to logSymbol() since it passes
the symbol name as the format string.  This could theoretically
be exploited by somehow getting format string escapes into a symbol name.

Fixed because of a build which added -Wformat-security and -Werror,
which led to a build failure.
