### PR TITLE
brltty.spec.in points to a now non-existing directory.

### DIFF
--- a/brltty.spec.in
+++ b/brltty.spec.in
@@ -25,8 +25,8 @@ License: GPL
 
 Vendor: The BRLTTY Developers
 Packager: Dave Mielke <dave@mielke.cc>
-URL: http://mielke.cc/brltty/
-Source: http://mielke.cc/brltty/releases/%{name}-%{version}.tar.gz
+URL: http://brltty.com/
+Source: http://brltty.com/archive/%{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-InstallRoot
 %define _bindir /bin


### PR DESCRIPTION
What used to be http://mielke.cc/releases/ does no longer
exist and now seems to be http://brltty.com/archive/.

Fix this in brltty.spec.in.
