### PR TITLE
respect $PKG_CONFIG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ reldeps.mk
 /autom4te*.cache
 /BinTree/
 
+/config.cache
 /config.log
 /config.status
 /config.mk
@@ -16,6 +17,7 @@ reldeps.mk
 /forbuild.mk
 /forbuild.h
 
+*~
 *.o
 *.a
 *.so

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -134,10 +134,10 @@ test -z "${$1_package}" && {
    test -n "${packages}" && {
       for package in ${packages}
       do
-         pkg-config --exists "${package}" && {
+         ${PKG_CONFIG} --exists "${package}" && {
             $1_package="${package}"
-            $1_includes=`pkg-config --cflags-only-I "${package}"`
-            $1_libs=`pkg-config ${pkgconfig_flags_libs} "${package}"`
+            $1_includes=`${PKG_CONFIG} --cflags-only-I "${package}"`
+            $1_libs=`${PKG_CONFIG} ${pkgconfig_flags_libs} "${package}"`
             break
          }
 
@@ -551,10 +551,10 @@ $1_includes=""
 $1_libs=""
 for package_specification in $2
 do
-   pkg-config --exists "${package_specification}" && {
+   ${PKG_CONFIG} --exists "${package_specification}" && {
       package_name="${package_specification%% *}"
-      $1_includes=`pkg-config --cflags-only-I "${package_name}"`
-      $1_libs=`pkg-config ${pkgconfig_flags_libs} "${package_name}"`
+      $1_includes=`${PKG_CONFIG} --cflags-only-I "${package_name}"`
+      $1_libs=`${PKG_CONFIG} ${pkgconfig_flags_libs} "${package_name}"`
       $3
       break
    }

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,9 @@ AC_PREFIX_DEFAULT([])
 AC_CONFIG_AUX_DIR([acdir])
 AC_CANONICAL_SYSTEM
 
+dnl This really should be using PKG_PROG_PKG_CONFIG.
+: ${PKG_CONFIG:=pkg-config}
+
 brltty_default_execute_root="/${PACKAGE_TARNAME}-${PACKAGE_VERSION}"
 BRLTTY_ARG_WITH(
    [execute-root], [DIRECTORY],
@@ -605,28 +608,28 @@ BRLTTY_ARG_DISABLE(
    [support for X11],
    [],
 [dnl
-   pkg-config --exists x11 && {
-      xsv_includes="`pkg-config --cflags-only-I x11`"
-      xsv_libs="`pkg-config ${pkgconfig_flags_libs} x11`"
+   ${PKG_CONFIG} --exists x11 && {
+      xsv_includes="`${PKG_CONFIG} --cflags-only-I x11`"
+      xsv_libs="`${PKG_CONFIG} ${pkgconfig_flags_libs} x11`"
 
       all_xbrlapi="all-xbrlapi"
       install_xbrlapi="install-xbrlapi"
 
       AC_CHECK_HEADERS([X11/keysym.h])
 
-      pkg-config --exists xext && {
-         xkb_libs="`pkg-config ${pkgconfig_flags_libs} xext` ${xkb_libs}"
+      ${PKG_CONFIG} --exists xext && {
+         xkb_libs="`${PKG_CONFIG} ${pkgconfig_flags_libs} xext` ${xkb_libs}"
 
-         pkg-config --exists xtst && {
-            xkb_libs="`pkg-config ${pkgconfig_flags_libs} xtst` ${xkb_libs}"
+         ${PKG_CONFIG} --exists xtst && {
+            xkb_libs="`${PKG_CONFIG} ${pkgconfig_flags_libs} xtst` ${xkb_libs}"
 
             AC_CHECK_HEADERS([X11/extensions/XTest.h])
             AC_CHECK_HEADERS([X11/extensions/XKB.h])
          }
       }
 
-      pkg-config --exists xt && {
-         xtk_libs="`pkg-config ${pkgconfig_flags_libs} xt` ${xtk_libs}"
+      ${PKG_CONFIG} --exists xt && {
+         xtk_libs="`${PKG_CONFIG} ${pkgconfig_flags_libs} xt` ${xtk_libs}"
 
          brltty_cppflags_save="${CPPFLAGS}"
          CPPFLAGS="${CPPFLAGS} ${xsv_includes}"


### PR DESCRIPTION
We don't want to hardcode `pkg-config` because that breaks cross-compiling
that supplies its own pkg-config wrapper.  At least respect the PKG_CONFIG
env var like the upstream pkg-config m4 intends.

Really this code should be using PKG_PROG_PKG_CONFIG, but the brltty seems
to be avoiding standard tools like aclocal and autoheader and automake.
