### PR TITLE
.gitignore fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ reldeps.mk
 *.xz
 
 /lib/
+
+/Programs/brltty-config


### PR DESCRIPTION
Although Programs/brltty-config is generated, it is not ignored by git and
hence appears in git status.
