### PR TITLE
Delegate acknowledgement handling to the core.

### DIFF
--- a/Drivers/Braille/HandyTech/brldefs-ht.h
+++ b/Drivers/Braille/HandyTech/brldefs-ht.h
@@ -50,6 +50,7 @@ typedef enum {
 
 /* Packet definition */
 typedef enum {
+  HT_PKT_Braille  = 0X01,
   HT_PKT_Extended = 0X79,
   HT_PKT_NAK      = 0X7D,
   HT_PKT_ACK      = 0X7E,
@@ -58,7 +59,7 @@ typedef enum {
 } HT_PacketType;
 
 typedef enum {
-  HT_EXTPKT_Braille               = 0X01,
+  HT_EXTPKT_Braille               = HT_PKT_Braille,
   HT_EXTPKT_Key                   = 0X04,
   HT_EXTPKT_Confirmation          = 0X07,
   HT_EXTPKT_Scancode              = 0X09,


### PR DESCRIPTION
This is my attempt of switching the HandyTech driver to using writeBrailleMessage()
and friends.  I am running that code right now, so it is tested.

From a log, I somehow suspect that messages do get reordered, not only overridden.
Is that possible?  I saw a toggle command enqueued, and then write braille requests.
But somehow, the write braille requests kept going, while the toggle command was
somehow delayed.  Do we check if the queue contains items, before adding to the
front?  In other words, it felt rather FILO, rather than FIFO.
