### PR TITLE
Make braille message queue reordering configurable.

### DIFF
--- a/Drivers/Braille/HandyTech/braille.c
+++ b/Drivers/Braille/HandyTech/braille.c
@@ -1263,6 +1263,8 @@ brl_construct (BrailleDisplay *brl, char **parameters, const char *device) {
 
       setTime = !!setTime;
 
+      brl->message.compareItems = NULL;
+
       if (probeBrailleDisplay(brl, 3, NULL, 100,
                               brl_reset,
                               readPacket, &response, sizeof(response),

--- a/Programs/brl.c
+++ b/Programs/brl.c
@@ -28,6 +28,7 @@
 #include "charset.h"
 #include "unicode.h"
 #include "brl.h"
+#include "brl_base.h"
 #include "ttb.h"
 #include "ktb.h"
 #include "queue.h"
@@ -56,6 +57,7 @@ constructBrailleDisplay (BrailleDisplay *brl) {
   brl->rotateInput = NULL;
 
   brl->message.queue = NULL;
+  brl->message.compareItems = compareBrailleMessages;
   brl->message.alarm = NULL;
   brl->message.timeout = BRAILLE_MESSAGE_ACKNOWLEDGEMENT_TIMEOUT;
 

--- a/Programs/brl_base.c
+++ b/Programs/brl_base.c
@@ -362,7 +362,7 @@ findOldBrailleMessage (const void *item, void *data) {
   return old->priority == new->priority;
 }
 
-static int
+int
 compareBrailleMessages (const void *item1, const void *item2, void *data) {
   const BrailleMessage *new = item1;
   const BrailleMessage *old = item2;
@@ -387,7 +387,7 @@ writeBrailleMessage (
     BrailleMessage *msg;
 
     if (!brl->message.queue) {
-      if (!(brl->message.queue = newQueue(deallocateBrailleMessageItem, compareBrailleMessages))) {
+      if (!(brl->message.queue = newQueue(deallocateBrailleMessageItem, brl->message.compareItems))) {
         return 0;
       }
     }

--- a/Programs/brl_base.h
+++ b/Programs/brl_base.h
@@ -102,6 +102,8 @@ extern int writeBraillePacket (
   const void *packet, size_t size
 );
 
+extern int compareBrailleMessages (const void *item1, const void *item2, void *data);
+
 extern int writeBrailleMessage (
   BrailleDisplay *brl, GioEndpoint *endpoint,
   int priority,

--- a/Programs/brl_types.h
+++ b/Programs/brl_types.h
@@ -90,6 +90,7 @@ struct BrailleDisplayStruct {
 
   struct {
     Queue *queue;
+    ItemComparator *compareItems;
     AsyncHandle alarm;
     int timeout;
   } message;


### PR DESCRIPTION
And set the comparator to NULL for the HandyTech driver such that outgoing
packets are not reordered based on packet type.
