### PR TITLE
Enable some security features in systemd service file.

### DIFF
--- a/Autostart/Systemd/brltty.service
+++ b/Autostart/Systemd/brltty.service
@@ -23,6 +23,10 @@ RestartSec=30
 Nice=-10
 OOMScoreAdjust=-900
 
+ProtectHome=read-only
+ProtectSystem=full
+SystemCallArchitectures=native
+
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
ProtectHome=read-only eensures that BRLTTY can not write to /home.
ProtectSystem=full ensures that /etc and /usr are read-only.
SystemCallArchitectures=native only leaves syscalls for the native architecture
enabled.  So on x86-64, 32bit binary code will likely fail (and vice versa)

All of these are to make it harder for an attacker, should they ever
manage to exploit BRLTTY, to actually tamper with the system.

It is a pitty that CAP_SYS_ADMIN is required for console insertion (which we
really use a lot) but also is a way to manually undo the
protections enabled above.  It would be nice if capabilities were
a little bit more fine grained here.  But as it stands, I think
enabling these options is a good thing, since it will make it harder to
make use of any potential exploits.

Having a capability for TIOCLINUX would still be very nice.
So we could use CapabilityBoundingSet= as well to limit the capabilities
to those we actually need.
