### PR TITLE
memcpy and mempcpy expect a nonnull argument. (ml)

### DIFF
--- a/Drivers/Braille/BrailleMemo/braille.c
+++ b/Drivers/Braille/BrailleMemo/braille.c
@@ -186,7 +186,7 @@ writePacket (
   *byte++ = (length >> 0) & 0XFF;
   *byte++ = (length >> 8) & 0XFF;
 
-  byte = mempcpy(byte, data, length);
+  if (data) byte = mempcpy(byte, data, length);
 
   return writeBytes(brl, bytes, byte-bytes);
 }

--- a/Drivers/Braille/HIMS/braille.c
+++ b/Drivers/Braille/HIMS/braille.c
@@ -249,7 +249,7 @@ writePacket (
   *byte++ = (length2 >> 8) & 0XFF;
 
   /* D2 */
-  byte = mempcpy(byte, data2, length2);
+  if (data2) byte = mempcpy(byte, data2, length2);
 
   /* DE2 */
   *byte++ = 0XF3;

--- a/Drivers/Braille/HandyTech/braille.c
+++ b/Drivers/Braille/HandyTech/braille.c
@@ -962,7 +962,7 @@ writeExtendedPacket (
   packet.fields.data.extended.model = brl->data->model->identifier;
   packet.fields.data.extended.length = size + 1; /* type byte is included */
   packet.fields.data.extended.type = type;
-  memcpy(packet.fields.data.extended.data.bytes, data, size);
+  if (data) memcpy(packet.fields.data.extended.data.bytes, data, size);
   packet.fields.data.extended.data.bytes[size] = SYN;
   size += 5; /* EXT, ID, LEN, TYPE, ..., SYN */
   return writeBrailleMessage(brl, NULL, type, &packet, size);

--- a/Drivers/Braille/HumanWare/braille.c
+++ b/Drivers/Braille/HumanWare/braille.c
@@ -103,7 +103,7 @@ writePacket (BrailleDisplay *brl, unsigned char type, unsigned char length, cons
   packet.fields.type = type;
   packet.fields.length = length;
 
-  memcpy(packet.fields.data.bytes, data, length);
+  if (data) memcpy(packet.fields.data.bytes, data, length);
   length += packet.fields.data.bytes - packet.bytes;
 
   return writeBraillePacket(brl, NULL, &packet, length);

--- a/Programs/usb_linux.c
+++ b/Programs/usb_linux.c
@@ -549,7 +549,7 @@ usbMakeURB (
     urb->usercontext = context;
     urb->buffer = (urb->buffer_length = length)? (urb + 1): NULL;
 
-    if (buffer) {
+    if (urb->buffer && buffer) {
       if (USB_ENDPOINT_DIRECTION(endpoint) == UsbEndpointDirection_Output) {
         memcpy(urb->buffer, buffer, length);
       }


### PR DESCRIPTION
This fixes a few warnings emitted by the LLVM/Clang static analyzer.