### PR TITLE
SystemCallArchitectures=native breaks the service on ARM for some reason. (ml)

### DIFF
--- a/Autostart/Systemd/brltty@.service.in
+++ b/Autostart/Systemd/brltty@.service.in
@@ -26,6 +26,5 @@ OOMScoreAdjust=-900
 
 ProtectHome=read-only
 ProtectSystem=full
-SystemCallArchitectures=native
 
 


### PR DESCRIPTION
SystemCallArchitectures=native in brltty@.service does not work at least on
Raspbian with two different types of Raspberries, better remove it to avoid
other people tripping over this.