### PR TITLE
Fix Actilino Joystick key processing. (ml)

### DIFF
--- a/Drivers/Braille/HandyTech/braille.c
+++ b/Drivers/Braille/HandyTech/braille.c
@@ -1433,7 +1433,7 @@ interpretByte_key (BrailleDisplay *brl, unsigned char byte) {
     return enqueueKeyEvent(brl, HT_GRP_NavigationKeys, byte, !release);
   }
 
-  if ((byte > 0) && (byte < 0X20)) {
+  if (byte > 0) {
     return enqueueKeyEvent(brl, HT_GRP_NavigationKeys, byte, !release);
   }
 


### PR DESCRIPTION
The Joystick Keys are an exception to how key codes have worked until now. 
Relax the check for navigation key group to allow them to be mapped.