### PR TITLE
Allow an amd64 brlapi.dll to be built using mingw-w64

### DIFF
--- a/Headers/prologue.h
+++ b/Headers/prologue.h
@@ -133,7 +133,7 @@ extern "C" {
 extern int gettimeofday (struct timeval *tvp, void *tzp);
 #endif /* gettimeofday */
 
-#if (__MINGW32_MAJOR_VERSION < 3) || ((__MINGW32_MAJOR_VERSION == 3) && (__MINGW32_MINOR_VERSION < 15))
+#if !defined(__MINGW64_VERSION_MAJOR) && ((__MINGW32_MAJOR_VERSION < 3) || ((__MINGW32_MAJOR_VERSION == 3) && (__MINGW32_MINOR_VERSION < 15)))
 extern void usleep (int usec);
 #endif /* usleep */
 #endif /* __MINGW32__ */

--- a/Headers/win_pthread.h
+++ b/Headers/win_pthread.h
@@ -271,12 +271,12 @@ typedef struct {
 } pthread_cond_t;
 #define PTHREAD_COND_INITIALIZER { NULL, 0}
 
-#ifndef __struct_timespec_defined
+#if !defined(__struct_timespec_defined) && !defined(__MINGW64_VERSION_MAJOR)
 struct timespec {
   time_t  tv_sec;  /* Seconds */
   long    tv_nsec; /* Nanoseconds */
 };
-#endif /* __struct_timespec_defined */
+#endif /* struct timespec */
 
 typedef unsigned pthread_condattr_t;
 

--- a/Programs/system_windows.c
+++ b/Programs/system_windows.c
@@ -541,7 +541,9 @@ getWindowsLocaleName (void) {
             LANGUAGE(LOWER_SORBIAN, "dsb");
             LANGUAGE(LUXEMBOURGISH, "lb");
             LANGUAGE(MACEDONIAN, "mk");
+#ifndef __MINGW64_VERSION_MAJOR
             LANGUAGE(MALAGASY, "mg");
+#endif
             LANGUAGE(MALAY, "ms");
             LANGUAGE(MALAYALAM, "ml");
             LANGUAGE(MALTESE, "mt");
@@ -633,7 +635,7 @@ gettimeofday (struct timeval *tvp, void *tzp) {
 }
 #endif /* gettimeofday() */
 
-#if (__MINGW32_MAJOR_VERSION < 3) || ((__MINGW32_MAJOR_VERSION == 3) && (__MINGW32_MINOR_VERSION < 15))
+#if !defined(__MINGW64_VERSION_MAJOR) && ((__MINGW32_MAJOR_VERSION < 3) || ((__MINGW32_MAJOR_VERSION == 3) && (__MINGW32_MINOR_VERSION < 15)))
 void
 usleep (int usec) {
   if (usec > 0) {


### PR DESCRIPTION
The mingw-w64 fork of mingw can produce native amd64 Windows binaries,
however it isn't fully compatible with the 32-bit mingw. This commit fixes
some minor compatibility issues, which leads to it being able to build the
client-side brlapi.dll.

Firstly, the `usleep` function that is patched in by BRLTTY for certain
versions of mingw is unnecessary when using mingw-w64, as it is already
exposed by its own libc headers. Therefore, this commit prevents the
compilation of this function if the compiler is detected to be mingw-w64.

Secondly, the `timespec` struct is also already provided when the
mingw-w64 libc is used, so it's similarly excluded.

These two changes are sufficient to get the brlapi.dll itself to compile
(i.e. the `api` make target). The last change makes sure that the
`all-api` target (the tests) can also be built. The LANG_MALAGASY is
undefined when using mingw-w64, so it is conditionally removed. Note that
this language constant is not officially supported [1] on Windows, so
removing it when the target is 64-bit Windows should not be harmful.

[1] List of Language Identifier and Constant Strings
    https://msdn.microsoft.com/en-us/library/windows/desktop/dd318693(v=vs.85).aspx