### PR TITLE
Build fixes for Solaris

### DIFF
--- a/Drivers/Braille/EuroBraille/eutp_brl.c
+++ b/Drivers/Braille/EuroBraille/eutp_brl.c
@@ -5,7 +5,9 @@
 ** Login   <obert01@epita.fr>
 */
 
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 500
+#endif
 
 /* globals */
 unsigned char extensions[] = {'K', 'L', 'B', 'T', 'A'};

--- a/Drivers/Braille/EuroBraille/eutp_transfer.c
+++ b/Drivers/Braille/EuroBraille/eutp_transfer.c
@@ -7,7 +7,9 @@
 ** Started on  Sun Mar 20 16:10:06 2005 Olivier BERT
 Last update Fri Jun  1 15:23:17 2007 Olivier BERT
 */
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 500
+#endif
 #include <sys/types.h>
 #include <dirent.h>
 #include <string.h>

--- a/Programs/beep_solaris.c
+++ b/Programs/beep_solaris.c
@@ -19,6 +19,7 @@
 #include "prologue.h"
 #include "log.h"
 
+#include <fcntl.h>
 #include <sys/kbio.h>
 #include <sys/kbd.h>
 

--- a/Programs/beep_solaris.c
+++ b/Programs/beep_solaris.c
@@ -17,6 +17,7 @@
  */
 
 #include "prologue.h"
+#include "log.h"
 
 #include <sys/kbio.h>
 #include <sys/kbd.h>

--- a/Programs/pcm_audio.c
+++ b/Programs/pcm_audio.c
@@ -18,6 +18,9 @@
 
 #include "prologue.h"
 
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <sys/audio.h>
 #include <stropts.h>
 

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,9 @@ in
    linux*|gnu*|kfreebsd*)
       brltty_prog_cc_sysflags="-D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=2 -D_BSD_SOURCE -D_XOPEN_SOURCE=500 -D_XOPEN_SOURCE_EXTENDED -D_GNU_SOURCE"
       ;;
+   solaris2.1?) # Solaris 10 & 11 require _XOPEN_SOURCE=600 if using C99
+      brltty_prog_cc_sysflags="-D_XOPEN_SOURCE=600 -D__EXTENSIONS__"
+      ;;
    solaris*)
       brltty_prog_cc_sysflags="-D_XOPEN_SOURCE=500 -D__EXTENSIONS__"
       ;;


### PR DESCRIPTION
These are patches we've been using to build the brltty-5.4 packages for Solaris.