### PR TITLE
Add an entry for BAUM_DEVICE_Orbit to baumDeviceOperations.

### DIFF
--- a/Drivers/Braille/Baum/braille.c
+++ b/Drivers/Braille/Baum/braille.c
@@ -1412,6 +1412,11 @@ static const BaumDeviceOperations baumDeviceOperations[] = {
     .writeAllCells = writeBaumCells_all
   },
 
+  [BAUM_DEVICE_Orbit] = {
+    .keyTableDefinition = &KEY_TABLE_DEFINITION(orbit),
+    .writeAllCells = writeBaumCells_all
+  },
+
   [BAUM_DEVICE_PocketVario] = {
     .keyTableDefinition = &KEY_TABLE_DEFINITION(pv),
     .writeAllCells = writeBaumCells_all


### PR DESCRIPTION
I think this was an accidental oversight?
