### PR TITLE
Drop -Wno-format from Python bindings

### DIFF
--- a/Bindings/Python/bindings.m4
+++ b/Bindings/Python/bindings.m4
@@ -121,7 +121,7 @@ fi
 
 if test "${GCC}" = "yes"
 then
-   CYTHON_CFLAGS="-Wno-parentheses -Wno-unused -Wno-format -fno-strict-aliasing -U_POSIX_C_SOURCE -U_XOPEN_SOURCE"
+   CYTHON_CFLAGS="-Wno-parentheses -Wno-unused -fno-strict-aliasing -U_POSIX_C_SOURCE -U_XOPEN_SOURCE"
 else
    case "${host_os}"
    in


### PR DESCRIPTION
This causes a build error on GCC7:
cc1: error: -Wformat-security ignored without -Wformat [-Werror=format-security]

It is also no longer necessary, as the bindings do not have format
security issues.