### PR TITLE
There is no need to register a default agent. (ml)

### DIFF
--- a/Documents/README.Bluetooth
+++ b/Documents/README.Bluetooth
@@ -127,14 +127,12 @@ enable scan mode:
    [CHG] Controller 01:23:45:67:89:AB Discovering: no
 
 To be able to receive PIN code requests directly on the console, you need to
-enable the *agent*, and to select the *default-agent*:
+enable the *agent*:
 
 .. code-block:: console
 
    [bluetooth]# agent on
    Agent registered
-   [bluetooth]# default-agent
-   Default agent request successful
 
 Now you are finally ready to initiate the pairing:
 


### PR DESCRIPTION
"agent on" by itself is already enough to receive PINCode requests
for pairings initiated from this bluetoothctl session.
default-agent would redirect PINCode requests from other DBus sessions as well,
but this is not necessary in this scenario.