### PR TITLE
Add support for "EsysLight80" and "EsytimeEvolution"

### DIFF
--- a/Drivers/Braille/EuroBraille/brldefs-eu.h
+++ b/Drivers/Braille/EuroBraille/brldefs-eu.h
@@ -42,8 +42,11 @@ typedef enum {
   EU_ESYS_24             = 0X0A,
   EU_ESYS_64             = 0X0B,
   EU_ESYS_80             = 0X0C,
+  EU_ESYS_LIGHT_80       = 0x0D,
   EU_ESYTIME_32          = 0X0E,
-  EU_ESYTIME_32_STANDARD = 0X0F
+  EU_ESYTIME_32_STANDARD = 0X0F,
+  EU_ESYTIME_EVO         = 0x10,
+  EU_ESYTIME_EVO_STANDARD = 0x11
 } EU_EsysirisModel;
 
 typedef enum {

--- a/Drivers/Braille/EuroBraille/eu_esysiris.c
+++ b/Drivers/Braille/EuroBraille/eu_esysiris.c
@@ -289,6 +289,13 @@ static const ModelEntry modelTable[] = {
     .keyTable = &KEY_TABLE_DEFINITION(esys_large)
   },
 
+  { .modelIdentifier = EU_ESYS_LIGHT_80,
+    .modelName = "Esys Light 80",
+    .cellCount = 80,
+    .isEsys = 1,
+    .keyTable = &KEY_TABLE_DEFINITION(esys_large)
+  },
+
   { .modelIdentifier = EU_ESYTIME_32,
     .modelName = "Esytime 32",
     .cellCount = 32,
@@ -300,6 +307,23 @@ static const ModelEntry modelTable[] = {
 
   { .modelIdentifier = EU_ESYTIME_32_STANDARD,
     .modelName = "Esytime 32 Standard",
+    .cellCount = 32,
+    .hasBrailleKeyboard = 1,
+    .isEsytime = 1,
+    .keyTable = &KEY_TABLE_DEFINITION(esytime)
+  },
+
+  { .modelIdentifier = EU_ESYTIME_EVO,
+    .modelName = "Esytime evolution",
+    .cellCount = 32,
+    .hasBrailleKeyboard = 1,
+    .hasOpticalBar = 1,
+    .isEsytime = 1,
+    .keyTable = &KEY_TABLE_DEFINITION(esytime)
+  },
+
+  { .modelIdentifier = EU_ESYTIME_EVO_STANDARD,
+    .modelName = "Esytime evolution Standard",
     .cellCount = 32,
     .hasBrailleKeyboard = 1,
     .isEsytime = 1,


### PR DESCRIPTION
EsysLight80 is a new braille display likes Esys 80 but without keyboard.
Esytime Evolution is a new braille note likes Esytime but with bluetooth adapter.

These modifications allow brltty to work fine with these devices via USB port.

Thanks a lot to add this contribution.