### PR TITLE
Baum key left of d-pad as space.

### DIFF
--- a/Tables/Input/bm/b9b10.kti
+++ b/Tables/Input/bm/b9b10.kti
@@ -18,7 +18,7 @@
 
 note B9 and B10 are the keys immediately to the left and right of the joystick.
 
-bind B9 KEY_BACKSPACE
+map B9 SPACE
 assign space B10
 include keyboard.kti
 bind B9+RoutingKey SETLEFT


### PR DESCRIPTION
On Baum devices with b9 and b10 keys on the side of the joystick, both keys should be treated as space.

Currently, the key to the right (B10) is considered space, but the one on the left (B9) is considered backspace. For consistency it would be best to have both of them represent space. Backspace is still accessible with DOT 7.