### PR TITLE
Fix call to memset in Inceptor driver

### DIFF
--- a/Drivers/Braille/Inceptor/braille.c
+++ b/Drivers/Braille/Inceptor/braille.c
@@ -312,7 +312,7 @@ brl_writeWindow (BrailleDisplay *brl, const wchar_t *text) {
     int cursor;
 
     translateOutputCells(cells, brl->data->braille.cells, cellCount);
-    memset(attributes, sizeof(attributes), 0);
+    memset(attributes, 0, sizeof(attributes));
     cursor = 0;
 
     for (int i=0; i<cellCount; i+=1) {


### PR DESCRIPTION
The second and third parameters were reversed.