### PR TITLE
Added Lithuanian Braille tables ported from liblouis.

### DIFF
--- a/Tables/Contraction/lt.ctb
+++ b/Tables/Contraction/lt.ctb
@@ -1,0 +1,194 @@
+###############################################################################
+# BRLTTY - A background process providing access to the console screen (when in
+#          text mode) for a blind person using a refreshable braille display.
+#
+# Copyright (C) 1995-2017 by The BRLTTY Developers.
+#
+# BRLTTY comes with ABSOLUTELY NO WARRANTY.
+#
+# This is free software, placed under the terms of the
+# GNU Lesser General Public License, as published by the Free Software
+# Foundation; either version 2.1 of the License, or (at your option) any
+# later version. Please see the file LICENSE-LGPL for details.
+#
+# Web Page: http://brltty.com/
+#
+# This software is maintained by Dave Mielke <dave@mielke.cc>.
+###############################################################################
+
+# BRLTTY Contraction Table - Lithuanian (uncontracted)
+#
+# Copyright (C) 2017 Rimas Kudelis <rq@akl.lt>
+# Copyright (C) 2017 Tadas Matusevičius <tadas.matus@gmail.com>
+#
+# The Lithuanian 6-dot Braille alphabet is described in a decree
+# no. 878 of the Minister of Education, called "Dėl perėjimo prie
+# naujos lietuviškos Brailio rašto abėcėlės tvarkos ir programos",
+# which is in effect since 2000-07-08. Document number is 55-1620. At
+# the time of writing this file, the document was accessible at
+# https://www.e-tar.lt/portal/lt/legalAct/TAR.A110E8E6A83F .
+# The document is referred to as "the standard" below.
+#
+# The standard specifies only the mapping of Lithuanian letters to 6-dot
+# Braille writing system, no other characters are defined in it.
+# Definitions of some punctuation and other characters are informally
+# available on the Internet.
+#
+# This table builds on from these bits of information, but also adds
+# a number of other definitions to make it more useful in computing.
+#
+# This table is based on the respective liblouis table.
+
+###
+### LETTERS
+###
+
+# Base Latin letters
+include letters-latin.cti
+
+# Letters with diacritics which are part of the Lithuanian alphabet
+always ą 16
+always Ą 16
+always č 146
+always Č 146
+always ę 156
+always Ę 156
+always ė 345
+always Ė 345
+always į 246
+always Į 246
+always š 2346
+always Š 2346
+always ų 346
+always Ų 346
+always ū 1256
+always Ū 1256
+always ž 126
+always Ž 126
+
+
+###
+### DIGITS
+###
+
+always 1 1
+always 2 12
+always 3 14
+always 4 145
+always 5 15
+always 6 124
+always 7 1245
+always 8 125
+always 9 24
+always 0 245
+
+
+###
+### PUNCTUATION
+###
+
+always ( 2356
+always ) 2356
+always [ 12356
+always ] 23456
+always { 6-246
+always } 6-135
+
+always – 6-36               U+2013 EN DASH
+
+# These are the typographically correct quotes in Lithuanian texts.
+always „ 236                U+201E DOUBLE LOW-9 QUOTATION MARK
+always “ 356                U+201C LEFT DOUBLE QUOTATION MARK
+
+# The following quotation characters should not be used in Lithuanian texts.
+always ” 6-4                U+201D RIGHT DOUBLE QUOTATION MARK
+always ” 6-4                U+201F DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+always « 6-4                U+00AB LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+always » 6-4                U+00BB RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+always ‹ 6-4                U+2039 SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+always › 6-4                U+203A SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+
+always … 256-256-256        U+2026 HORIZONTAL ELLIPSIS
+repeatable … 256-256-256    U+2026 HORIZONTAL ELLIPSIS
+repeatable ... 256-256-256  Three times U+002E FULL STOP
+
+
+###
+### MATHEMATICAL SYMBOLS
+###
+
+always + 5-235
+always − 5-36               U+2212 MINUS SIGN
+always < 5-246
+always = 5-2356
+always > 5-135
+always ± 5-235-36
+always ∓ 5-36-235           U+2213 MINUS-OR-PLUS SIGN
+always × 5-3
+always ⋅ 5-3                U+22C5 DOT OPERATOR
+always ÷ 5-256
+always ∶ 5-256              U+2236 RATIO
+always ⁄ 34                 U+2044 FRACTION SLASH
+always ∕ 34                 U+2215 DIVISION SLASH
+
+
+###
+### OTHER CHARACTERS
+###
+
+always # 6-3456
+always $ 6-46
+always @ 6-345
+always \ 6-34
+always ^ 6-256
+always _ 1456
+always | 6-456
+#always ¦ 6-1456
+always § 6-345
+#always ¬ 6-235
+always µ 6-134
+#always ¶ 6-1234
+
+always ` 6-3
+always ~ 6-26
+
+#always ¢ 6-14
+always £ 6-123
+always € 6-15               U+20AC EURO SIGN
+
+always • 6-35               U+2022 BULLET
+
+always © 2356-46-14-2356
+always ® 2356-46-1235-2356
+always ℗ 2356-46-1234-2356  U+2117 SOUND RECORDING COPYRIGHT
+
+always ← 246-25             U+2190 LEFTWARDS ARROW
+always → 25-135             U+2192 RIGHTWARDS ARROW
+
+# Middle dot is unlikely to appear in text, except perhaps as a multiplication sign (dot operator).
+always · 5-3                U+00B7 MIDDLE DOT
+
+always ° 5-356
+always ′ 5-35               U+2032 PRIME
+always ″ 5-35-35            U+2033 DOUBLE PRIME
+
+always ℃ 5-356-46-14        U+2103 DEGREE CELSIUS
+always ℉ 5-356-46-124       U+2109 DEGREE FAHRENHEIT
+
+
+###
+### INDICATOR AND SPECIAL SYMBOL DIRECTIVES
+###
+
+numsign 3456  number sign, just one operand
+letsign 56
+capsign 46
+begcaps 456
+endcaps 56
+
+midnum , 2
+midnum : 25
+midnum . 256
+
+# when a decimal begins with a period, it should be translated with a 
+# number sign followed by a decimal point, followed by the number.

--- a/Tables/Text/lt.ttb
+++ b/Tables/Text/lt.ttb
@@ -18,27 +18,172 @@
 
 # BRLTTY Text Table - Lituanian
 #
-# Samuel Thibault <samuel.thibault@ens-lyon.org>
-# 
-# This table is based on the Unesco report on the progress of unification of
-# braille writing « L'ÉCRITURE BRAILLE DANS LE MONDE », by Sir Clutha
-# MACKENZIE: http://unesdoc.unesco.org/images/0013/001352/135251fo.pdf
-# The document is dated 1954, so this table may be quite outdated.
+# Copyright (C) 2017 Rimas Kudelis <rq@akl.lt>
+#
+# The Lithuanian 8-dot Braille writing system is described in a decree of the Minister of
+# Social Security and Labor, called "Dėl vieningos aštuonių taškų Brailio rašto sistemos
+# naudojimo tvarkos aprašo patvirtinimo", which is in effect since 2011-04-13. Document
+# number is A1-183. At the time of writing this file, the document was accessible at
+# https://www.e-tar.lt/portal/lt/legalAct/TAR.443D667CA047 .
+# The document is referred to as "the standard" below.
+#
+# The standard maps ISO-8859-13 character set to 8-dot Braille writing system. However,
+# even though it defines different mappings for literary and computer braille modes, it
+# doesn't seem like the authors had a good understanding of why these two modes exist
+# and how they differ. Furthermore, the standard contains a few errors (incorrectly named
+# characters as well as mapping conflicts). I would say it needs further improvements.
+#
+# This file is based on the standard, but does not exactly follow it. Some standard
+# definitions are commented out, some changed, and some extra ones are added.
+#
+# This table is based on the respective liblouis table.
 
-# the standard representations for the letters of the Latin alphabet
+
+###
+### LETTERS
+###
+
+# Standard representations for the letters of the Latin alphabet
 include ltr-latin.tti
 
-# lowercase accented letters
+# Lowercase accented letters
+char \u0105	(1    6  )  # ⠡ ą [LATIN SMALL LETTER A WITH OGONEK]
 char \u010D	(1  4 6  )  # ⠩ č [LATIN SMALL LETTER C WITH CARON]
+char \u0119	(1   56  )  # ⠱ ę [LATIN SMALL LETTER E WITH OGONEK]
+char \u0117	(  345   )  # ⠜ ė [LATIN SMALL LETTER E WITH DOT ABOVE]
+char \u012F	( 2 4 6  )  # ⠪ į [LATIN SMALL LETTER I WITH OGONEK]
 char \u0161	( 234 6  )  # ⠮ š [LATIN SMALL LETTER S WITH CARON]
+char \u0173	(  34 6  )  # ⠬ ų [LATIN SMALL LETTER U WITH OGONEK]
+char \u016B	(12  56  )  # ⠳ ū [LATIN SMALL LETTER U WITH MACRON]
+char \u017E	(12   6  )  # ⠣ ž [LATIN SMALL LETTER Z WITH MACRON]
 
-# lowercase accented letters
+# Uppercase accented letters
+char \u0104	(1    67 )  # ⡡ Ą [LATIN CAPITAL LETTER A WITH OGONEK]
 char \u010C	(1  4 67 )  # ⡩ Č [LATIN CAPITAL LETTER C WITH CARON]
+char \u0118	(1   567 )  # ⡱ Ę [LATIN CAPITAL LETTER E WITH OGONEK]
+char \u0116	(  345 7 )  # ⡜ Ė [LATIN CAPITAL LETTER E WITH DOT ABOVE]
+char \u012E	( 2 4 67 )  # ⡪ Į [LATIN CAPITAL LETTER I WITH OGONEK]
 char \u0160	( 234 67 )  # ⡮ Š [LATIN CAPITAL LETTER S WITH CARON]
+char \u0172	(  34 67 )  # ⡬ Ų [LATIN CAPITAL LETTER U WITH OGONEK]
+char \u016A	(12  567 )  # ⡳ Ū [LATIN CAPITAL LETTER U WITH MACRON]
+char \u017D	(12   67 )  # ⡣ Ž [LATIN CAPITAL LETTER Z WITH CARON]
 
-# the numbers 0-9 are represented by the letters j,a-i with dot 8 added
+
+###
+### DIGITS
+###
+
+# Digits 0-9 are represented by the letters j,a-i with dot 8 added
 include num-dot8.tti
 
-include punc-basic.tti
+
+###
+### PUNCTUATION
+###
+
+char \x2C	( 2      )  # ⠂ , [COMMA]
+char \x2E	( 2  56  )  # ⠲ . [FULL STOP]
+char \x3F	( 2   6  )  # ⠢ ? [QUESTION MARK]
+char \x21	( 23 5   )  # ⠖ ! [EXCLAMATION MARK]
+char \x3A	( 2  5   )  # ⠒ : [COLON]
+char \x3B	( 23     )  # ⠆ ; [SEMICOLON]
+char \x22	(   4    )  # ⠈ " [QUOTATION MARK]
+char \x27	(  3     )  # ⠄ ' [APOSTROPHE]
+# The following character is defined as 134568 in the standard, but that is hardly useful.
+# According to Unicode, it is the preferred character to use for apostrophe, hence
+# defining it as one here.
+alias \u2019	\x27        #   ’ [RIGHT SINGLE QUOTATION MARK]
+
+char \x28	( 23 567 )  # ⡶ ( [LEFT PARENTHESIS]
+char \x29	( 23 56 8)  # ⢶ ) [RIGHT PARENTHESIS]
+char \x5B	(123 56  )  # ⠷ [ LEFT SQUARE BRACKET
+char \x5D	( 23456  )  # ⠾ ] RIGHT SQUARE BRACKET
+char \x7B	( 2 4 678)  # ⣪ { LEFT CURLY BRACKET
+char \x7D	(1 3 5 78)  # ⣕ } RIGHT CURLY BRACKET
+
+char \x2D	(  3  6  )  # ⠤ - [HYPHEN-MINUS]
+# Soft hyphen is defined as 368 in the standard.
+alias \xAD	\x2D        #   ­ [SOFT HYPHEN]
+# The following characters are not defined in the standard.
+alias \u2010	\x2D        #   ‐ [HYPHEN]
+alias \u2011	\x2D        #   ‑ [NON-BREAKING HYPHEN]
+alias \u2012	\x2D        #   ‒ [FIGURE DASH]
+alias \u2013	\x2D        #   – [EN DASH]
+alias \u2014	\x2D        #   — [EM DASH]
+alias \u2015	\x2D        #   ― [HORIZONTAL BAR]
+
+# These are the typographically correct quotes in Lithuanian texts.
+char \u201E	( 23  67 )  # ⡦ „ [DOUBLE LOW-9 QUOTATION MARK]
+char \u201C	(  3 567 )  # ⡴ “ [LEFT DOUBLE QUOTATION MARK]
+# The following characters are defined in the standard, because they exist in ISO-8859-13
+# character set, even though they should not be used in Lithuanian texts.
+char \u201D	(  3  67 )  # ⡤ ” [RIGHT DOUBLE QUOTATION MARK]
+char \xAB	(    5678)  # ⣰ « [LEFT-POINTING DOUBLE ANGLE QUOTATION MARK]
+char \xBB	(   45 78)  # ⣘ » [RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK]
+
+
+###
+### MATHEMATICAL SYMBOLS
+###
+
+char \x2B	( 23 5  8)  # ⢖ + [PLUS SIGN]
+# Real minus is not defined in the standard.
+alias \u2212	\x2D        #   − [MINUS SIGN]
+char \x3C	( 2 4 6 8)  # ⢪ < [LESS-THAN SIGN]
+char \x3D	( 23 56  )  # ⠶ = [EQUALS SIGN]
+char \x3E	(1 3 5  8)  # ⢕ > [GREATER-THAN SIGN]
+char \xB1	( 23 5 78)  # ⣖ ± [PLUS-MINUS SIGN]
+char \xD7	( 234   8)  # ⢎ × MULTIPLICATION SIGN]
+char \xF7	(12  5678)  # ⣳ ÷ [DIVISION SIGN]
+
+
+###
+### OTHER CHARACTERS
+###
+
+char \x23	(  3456  )  # ⠼ # [NUMBER SIGN]
+char \x24	(   4 6  )  # ⠨ $ [DOLLAR SIGN]
+char \x25	(123456  )  # ⠿ % [PERCENT SIGN]
+char \x26	(1234 6  )  # ⠯ & [AMPERSAND]
+char \x2A	(  3 5   )  # ⠔ * [ASTERISK]
+char \x2F	(  34    )  # ⠌ / [SOLIDUS]
+char \x40	(  345 78)  # ⣜ @ [COMMERCIAL AT]
+char \x5C	(  34  7 )  # ⡌ \ [REVERSE SOLIDUS]
+char \x5E	( 2  56 8)  # ⢲ ^ [CIRCUMFLEX ACCENT]
+char \x5F	(   4567 )  # ⡸ _ [LOW LINE]
+char \x7C	(   456  )  # ⠸ | [VERTICAL LINE]
+char \xA6	(1  456  )  # ⠹ ¦ [BROKEN BAR]
+char \xA7	(  34 6 8)  # ⢬ § [SECTION SIGN]
+char \xAC	(    5   )  # ⠐ ¬ [NOT SIGN]
+char \xB5	(1 34   8)  # ⢍ µ [MICRO SIGN]
+char \xB6	(1234   8)  # ⢏ ¶ [PILCROW SIGN]
+
+char \x60	(     6  )  # ⠠ ` [GRAVE ACCENT]
+char \x7E	( 2   6 8)  # ⢢ ~ [TILDE]
+
+char \xA2	(    5  8)  # ⢐ ¢ [CENT SIGN]
+char \xA3	(   4 67 )  # ⡨ £ [POUND SIGN]
+# Euro sign is not defined in the standard, but codepoint 0x80 of ISO-8859-13 is.
+# In Windows-1257, 0x80 is the Euro sign.
+# The unofficially distributed Lithuanian JAWS table specified all characters as
+# ANSI codes, thus rendering Euro as 457.
+# Not sure if I want to replicate that here though: who knows how this table will
+# end up being used and for how long. Aliasing to E instead.
+# char \u20AC	(   45 7 )  # ⡘ € [EURO SIGN]
+alias \u20AC	\x45        #   € [EURO SIGN]
+
+char \xA4	(   4 678)  # ⣨ ¤ [CURRENCY SIGN]
+
+char \xA9	(1234 6 8)  # ⢯ © COPYRIGHT SIGN
+char \xAE	(123 5  8)  # ⢗ ® [REGISTERED SIGN]
+
+# Middle dot is unlikely to appear in text, except perhaps as a multiplication sign (dot operator).
+char \xB7	(  3   7 )  # ⡄ · [MIDDLE DOT]
+
+char \xB0	(   456 8)  # ⢸ ° [DEGREE SIGN]
+
+char \xB9	(1     78)  # ⣁ ¹ [SUPERSCRIPT ONE]
+char \xB2	(12    78)  # ⣃ ² [SUPERSCRIPT TWO]
+char \xB3	(1  4  78)  # ⣉ ³ [SUPERSCRIPT THREE]
 
 include common.tti


### PR DESCRIPTION
This adds/updates Lithuanian Braille tables.

Please note that I haven't tested them as I'm not a Braille user myself, and I haven't stumbled upon any documentation on how to actually run the tests. Any help in that regard would be appreciated.

I've ported these tables from liblouis, but being relatively fresh, they are likely to change in future, especially the 8-dot one.