### PR TITLE
Check for ioperm to make sure the platform supports ports I/O. (ml)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1472,7 +1472,9 @@ BRLTTY_ARG_PACKAGE([ports], [I/O ports], [], [dnl
       ports_package="kfreebsd"
       ;;
    linux*)
-      ports_package="glibc"
+      AC_CHECK_FUNC([ioperm], [
+         ports_package="glibc"
+      ])
       ;;
    mingw*)
       ports_package="windows"


### PR DESCRIPTION
Ports I/O is an i386-specific thing.  Many architectures don't have it.
While inb/outb are not real functions (they are filled in by the
optimizer according to the manpages), ioperm is, and can easily
be tested for to check if the platform actually has ports I/O.