### PR TITLE
Add support for eSpeak-NG

### DIFF
--- a/Documents/Manual-BRLTTY/English/driver-codes.sgml
+++ b/Documents/Manual-BRLTTY/English/driver-codes.sgml
@@ -11,6 +11,7 @@ bn|BrailleNote@
 cb|CombiBraille@
 ec|EcoBraille@
 es|eSpeak@
+en|eSpeak-NG@
 eu|EuroBraille@
 fl|FestivalLite@
 fs|FreedomScientific@

--- a/Documents/Manual-BRLTTY/English/speech-drivers.sgml
+++ b/Documents/Manual-BRLTTY/English/speech-drivers.sgml
@@ -8,6 +8,8 @@ CombiBraille
   |@
 eSpeak
   |text to speech engine@
+eSpeak-NG
+  |text to speech engine@
 ExternalSpeech
   |runs /usr/local/bin/externalspeech@
 Festival

--- a/Documents/Manual-BRLTTY/French/driver-codes.sgml
+++ b/Documents/Manual-BRLTTY/French/driver-codes.sgml
@@ -11,6 +11,7 @@ bn|BrailleNote@
 cb|CombiBraille@
 ec|EcoBraille@
 es|eSpeak@
+en|eSpeak-NG@
 eu|EuroBraille@
 fl|FestivalLite@
 fs|FreedomScientific@

--- a/Documents/Manual-BRLTTY/French/speech-drivers.sgml
+++ b/Documents/Manual-BRLTTY/French/speech-drivers.sgml
@@ -6,6 +6,8 @@ CombiBraille
   |@
 eSpeak
   |text to speech engine@
+eSpeak-NG
+  |text to speech engine@
 ExternalSpeech
   |runs /usr/local/bin/externalspeech@
 Festival

--- a/Documents/Manual-BRLTTY/Portuguese/BRLTTY.htm
+++ b/Documents/Manual-BRLTTY/Portuguese/BRLTTY.htm
@@ -13626,6 +13626,10 @@ style='mso-spacerun:yes'>      </span>eSpeak<span
 style='mso-spacerun:yes'>           </span>text to speech engine<o:p></o:p></span></p>
 
 <p class=MsoPlainText><span lang=EN-US style='mso-ansi-language:EN-US'><span
+style='mso-spacerun:yes'>      </span>eSpeak-NG<span
+style='mso-spacerun:yes'>        </span>text to speech engine<o:p></o:p></span></p>
+
+<p class=MsoPlainText><span lang=EN-US style='mso-ansi-language:EN-US'><span
 style='mso-spacerun:yes'>     </span><span
 style='mso-spacerun:yes'> </span>ExternalSpeech<span
 style='mso-spacerun:yes'>   </span>runs /usr/local/bin/externalspeech<o:p></o:p></span></p>
@@ -14238,7 +14242,21 @@ de Driver</span><span style='font-family:Times;mso-bidi-font-family:"Courier New
   style='font-family:Times;mso-bidi-font-family:"Courier New"'><o:p></o:p></span></p>
   </td>
  </tr>
- <tr style='mso-yfti-irow:41;mso-yfti-lastrow:yes;height:29.6pt'>
+ <tr style='mso-yfti-irow:41'>
+  <td valign=top style='border:solid #AAAAAA 1.0pt;border-top:none;mso-border-top-alt:
+  solid #AAAAAA .75pt;mso-border-alt:solid #AAAAAA .75pt;padding:5.6pt 5.6pt 5.6pt 5.6pt'>
+  <p class=MsoPlainText><span style='font-size:11.0pt'>en</span><span
+  style='font-family:Times;mso-bidi-font-family:"Courier New"'><o:p></o:p></span></p>
+  </td>
+  <td valign=top style='border-top:none;border-left:none;border-bottom:solid #AAAAAA 1.0pt;
+  border-right:solid #AAAAAA 1.0pt;mso-border-top-alt:solid #AAAAAA .75pt;
+  mso-border-left-alt:solid #AAAAAA .75pt;mso-border-alt:solid #AAAAAA .75pt;
+  padding:5.6pt 5.6pt 5.6pt 5.6pt'>
+  <p class=MsoPlainText><span style='font-size:11.0pt'>eSpeak-NG</span><span
+  style='font-family:Times;mso-bidi-font-family:"Courier New"'><o:p></o:p></span></p>
+  </td>
+ </tr>
+ <tr style='mso-yfti-irow:42;mso-yfti-lastrow:yes;height:29.6pt'>
   <td valign=top style='border:solid #AAAAAA 1.0pt;border-top:none;mso-border-top-alt:
   solid #AAAAAA .75pt;mso-border-alt:solid #AAAAAA .75pt;padding:5.6pt 5.6pt 5.6pt 5.6pt;
   height:29.6pt'>
@@ -14588,6 +14606,10 @@ style='mso-spacerun:yes'>      </span>ec<span style='mso-spacerun:yes'>    
 <p class=MsoPlainText><span lang=EN-US style='mso-ansi-language:EN-US'><span
 style='mso-spacerun:yes'>      </span>es<span style='mso-spacerun:yes'>    
 </span>eSpeak<o:p></o:p></span></p>
+
+<p class=MsoPlainText><span lang=EN-US style='mso-ansi-language:EN-US'><span
+style='mso-spacerun:yes'>      </span>en<span style='mso-spacerun:yes'>    
+</span>eSpeak-NG<o:p></o:p></span></p>
 
 <p class=MsoPlainText><span lang=EN-US style='mso-ansi-language:EN-US'><span
 style='mso-spacerun:yes'>      </span>eu<span style='mso-spacerun:yes'>    

--- a/Documents/Manual-BRLTTY/Portuguese/BRLTTY.txt
+++ b/Documents/Manual-BRLTTY/Portuguese/BRLTTY.txt
@@ -5578,6 +5578,7 @@ B. Sintetizadores de Fala Suportados:
       BrailleLite
       CombiBraille
       eSpeak           text to speech engine
+      eSpeak-NG        text to speech engine
       ExternalSpeech   runs /usr/local/bin/externalspeech
       Festival         text to speech engine
       FestivalLite     text to speech engine
@@ -5608,6 +5609,8 @@ ec
 EcoBraille
 es
 eSpeak
+en
+eSpeak-NG
 eu
 EuroBraille
 fl
@@ -5771,6 +5774,7 @@ selecionar a opção padrão do sistema Hurd.
       cb     CombiBraille
       ec     EcoBraille
       es     eSpeak
+      en     eSpeak-NG
       eu     EuroBraille
       fl     FestivalLite
       fs     FreedomScientific

--- a/Documents/README.DOS
+++ b/Documents/README.DOS
@@ -286,6 +286,7 @@ You should be able to use a configure command like this one::
       --without-usb-package --without-bluetooth-package \
       --without-libbraille --with-braille-driver=-vr,all \
       --without-espeak --without-flite \
+      --without-espeak-ng \
       --without-speechd --with-speech-driver=all \
       --with-screen-driver=pb,-all
 

--- a/Documents/brltty.1.in
+++ b/Documents/brltty.1.in
@@ -717,6 +717,9 @@ EcoBraille
 .B es
 eSpeak
 .TP 4
+.B en
+eSpeak-NG
+.TP 4
 .B eu
 EuroBraille
 .TP 4

--- a/Documents/brltty.conf.in
+++ b/Documents/brltty.conf.in
@@ -344,6 +344,7 @@
 #speech-driver	bl	# BrailleLite
 #speech-driver	cb	# CombiBraille
 #speech-driver	es	# eSpeak (text to speech engine)
+#speech-driver	en	# eSpeak-NG (text to speech engine)
 #speech-driver	fl	# FestivalLite (text to speech engine)
 #speech-driver	fv	# Festival (text to speech engine)
 #speech-driver	gs	# GenericSay (pipes to /usr/local/bin/say)
@@ -382,6 +383,12 @@
 #speech-parameters es:Path=
 #speech-parameters es:PunctList=
 #speech-parameters es:Voice=default
+
+# eSpeak-NG Speech Driver Parameters
+#speech-parameters en:MaxRate=450 # [80-]
+#speech-parameters en:Path=
+#speech-parameters en:PunctList=
+#speech-parameters en:Voice=en
 
 # ExternalSpeech Speech Driver Parameters
 #speech-parameters xs:Program=/usr/local/bin/externalspeech

--- a/Documents/speech-driver.csv
+++ b/Documents/speech-driver.csv
@@ -4,6 +4,7 @@
 "bl","BrailleLite"
 "cb","CombiBraille"
 "es","eSpeak (text to speech engine)"
+"en","eSpeak-NG (text to speech engine)"
 "fl","FestivalLite (text to speech engine)"
 "fv","Festival (text to speech engine)"
 "gs","GenericSay (pipes to /usr/local/bin/say)"

--- a/Drivers/Speech/eSpeak-NG/Makefile.in
+++ b/Drivers/Speech/eSpeak-NG/Makefile.in
@@ -1,0 +1,29 @@
+###############################################################################
+# BRLTTY - A background process providing access to the console screen (when in
+#          text mode) for a blind person using a refreshable braille display.
+#
+# Copyright (C) 1995-2018 by The BRLTTY Developers.
+#
+# BRLTTY comes with ABSOLUTELY NO WARRANTY.
+#
+# This is free software, placed under the terms of the
+# GNU Lesser General Public License, as published by the Free Software
+# Foundation; either version 2.1 of the License, or (at your option) any
+# later version. Please see the file LICENSE-LGPL for details.
+#
+# Web Page: http://brltty.com/
+#
+# This software is maintained by Dave Mielke <dave@mielke.cc>.
+###############################################################################
+
+DRIVER_CODE = en
+DRIVER_NAME = eSpeak-NG
+DRIVER_COMMENT = text to speech engine
+DRIVER_VERSION = 0.1
+DRIVER_DEVELOPERS = Nicolas Pitre <nico@fluxnic.net>, Ondřej Lysoněk <olysonek@redhat.com>
+SPK_OBJS = @speech_libraries_en@
+include $(SRC_TOP)speech.mk
+
+speech.$O:
+	$(CC) $(SPK_CFLAGS) -I$(ESPEAK_NG_ROOT)/include -c $(SRC_DIR)/speech.c
+

--- a/Drivers/Speech/eSpeak-NG/README
+++ b/Drivers/Speech/eSpeak-NG/README
@@ -1,0 +1,34 @@
+This directory contains the BRLTTY speech driver for the eSpeak-NG text to
+speech engine.  The eSpeak-NG web site is
+https://github.com/espeak-ng/espeak-ng/.
+
+eSpeak-NG comes with a simple command-line tool called espeak-ng which can be
+used to test it, and to recompile modified dictionaries, etc. Please see
+the espeak-ng man page for more information.
+
+BRLTTY's configure script automatically includes this driver if the
+eSpeak-NG development library is installed.
+
+This driver recognizes the following parameters:
+
+path
+
+	Specifies the directory containing the espeak-ng-data directory.
+	If not specified, the default location is used.
+	
+punctlist
+
+	Specified a list of punctuation characters whose names are to be
+	spoken when the speech punctuation parameter is set to "Some".
+	If not specified, a default list is used.
+
+voice
+
+	Specifies a voice/language to use.  The complete list of available
+	voices may be obtained with the command 'espeak-ng --voices'.
+
+maxrate
+
+	Overrides the maximum speech rate value. The default is 450.
+	This cannot be lower than 80.
+

--- a/Drivers/Speech/eSpeak-NG/speech.c
+++ b/Drivers/Speech/eSpeak-NG/speech.c
@@ -1,0 +1,174 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2018 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.com/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+#include "prologue.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "log.h"
+#include "parse.h"
+
+typedef enum {
+	PARM_PATH,
+	PARM_PUNCTLIST,
+	PARM_VOICE,
+	PARM_MAXRATE
+} DriverParameter;
+#define SPKPARMS "path", "punctlist", "voice", "maxrate"
+
+#include "spk_driver.h"
+
+#include <espeak-ng/speak_lib.h>
+
+static int maxrate = espeakRATE_MAXIMUM;
+
+static void
+spk_say(volatile SpeechSynthesizer *spk, const unsigned char *buffer, size_t length, size_t count, const unsigned char *attributes)
+{
+	int result;
+
+	/* add 1 to the length in order to pass along the trailing zero */
+	result = espeak_Synth(buffer, length+1, 0, POS_CHARACTER, 0,
+			espeakCHARS_UTF8, NULL, (void *)spk);
+	if (result != EE_OK)
+		logMessage(LOG_ERR, "eSpeak-NG: Synth() returned error %d", result);
+}
+
+static void
+spk_mute(volatile SpeechSynthesizer *spk)
+{
+	espeak_Cancel();
+}
+
+static int SynthCallback(short *audio, int numsamples, espeak_EVENT *events)
+{
+	volatile SpeechSynthesizer *spk = events->user_data;
+
+	while (events->type != espeakEVENT_LIST_TERMINATED) {
+		if (events->type == espeakEVENT_WORD)
+			tellSpeechLocation(spk, events->text_position - 1);
+		if (events->type == espeakEVENT_MSG_TERMINATED)
+			tellSpeechFinished(spk);
+		events++;
+	}
+	return 0;
+}
+
+static void
+spk_drain(volatile SpeechSynthesizer *spk)
+{
+	espeak_Synchronize();
+}
+
+static void
+spk_setVolume(volatile SpeechSynthesizer *spk, unsigned char setting)
+{
+	int volume = getIntegerSpeechVolume(setting, 50);
+	espeak_SetParameter(espeakVOLUME, volume, 0);
+}
+
+static void
+spk_setRate(volatile SpeechSynthesizer *spk, unsigned char setting)
+{
+	int h_range = (maxrate - espeakRATE_MINIMUM)/2;
+	int rate = getIntegerSpeechRate(setting, h_range) + espeakRATE_MINIMUM;
+	espeak_SetParameter(espeakRATE, rate, 0);
+}
+
+static void
+spk_setPitch(volatile SpeechSynthesizer *spk, unsigned char setting)
+{
+	int pitch = getIntegerSpeechPitch(setting, 50);
+	espeak_SetParameter(espeakPITCH, pitch, 0);
+}
+
+static void
+spk_setPunctuation(volatile SpeechSynthesizer *spk, SpeechPunctuation setting)
+{
+	espeak_PUNCT_TYPE punct;
+	if (setting <= SPK_PUNCTUATION_NONE)
+		punct = espeakPUNCT_NONE;
+	else if (setting >= SPK_PUNCTUATION_ALL)
+		punct = espeakPUNCT_ALL;
+	else
+		punct = espeakPUNCT_SOME;
+	espeak_SetParameter(espeakPUNCTUATION, punct, 0);
+}
+
+static int spk_construct(volatile SpeechSynthesizer *spk, char **parameters)
+{
+	char *data_path, *voicename, *punctlist;
+	int result;
+
+	spk->setVolume = spk_setVolume;
+	spk->setRate = spk_setRate;
+	spk->setPitch = spk_setPitch;
+	spk->setPunctuation = spk_setPunctuation;
+	spk->drain = spk_drain;
+
+	logMessage(LOG_INFO, "eSpeak-NG version %s", espeak_Info(NULL));
+
+	data_path = parameters[PARM_PATH];
+	if (data_path && !*data_path)
+		data_path = NULL;
+	result = espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 0, data_path, 0);
+	if (result < 0) {
+		logMessage(LOG_ERR, "eSpeak-NG: initialization failed");
+		return 0;
+	}
+
+	voicename = parameters[PARM_VOICE];
+	if(!voicename || !*voicename)
+		voicename = "en";
+	result = espeak_SetVoiceByName(voicename);
+	if (result != EE_OK) {
+		espeak_VOICE voice_select;
+		memset(&voice_select, 0, sizeof(voice_select));
+		voice_select.languages = voicename;
+		result = espeak_SetVoiceByProperties(&voice_select);
+	}
+	if (result != EE_OK) {
+		logMessage(LOG_ERR, "eSpeak-NG: unable to load voice '%s'", voicename);
+		return 0;
+	}
+
+	punctlist = parameters[PARM_PUNCTLIST];
+	if (punctlist && *punctlist) {
+		wchar_t w_punctlist[strlen(punctlist) + 1];
+		int i = 0;
+		while ((w_punctlist[i] = punctlist[i]) != 0) i++;
+		espeak_SetPunctuationList(w_punctlist);
+	}
+
+	if (parameters[PARM_MAXRATE]) {
+		int val = atoi(parameters[PARM_MAXRATE]);
+		if (val > espeakRATE_MINIMUM) maxrate = val;
+	}
+
+	espeak_SetSynthCallback(SynthCallback);
+
+	return 1;
+}
+
+static void spk_destruct(volatile SpeechSynthesizer *spk)
+{
+	espeak_Cancel();
+	espeak_Terminate();
+}

--- a/README
+++ b/README
@@ -210,6 +210,7 @@ The following speech synthesizers are supported:
 -  BrailleLite
 -  CombiBraille
 -  eSpeak [text to speech engine]
+-  eSpeak-NG [text to speech engine]
 -  ExternalSpeech [runs /usr/local/bin/externalspeech]
 -  Festival [text to speech engine]
 -  FestivalLite [text to speech engine]

--- a/brltty.spec.in
+++ b/brltty.spec.in
@@ -144,6 +144,27 @@ Install this package if you would like to be able to use the
 eSpeak text-to-speech engine.
 
 
+%package -n brltty-speech-espeak-ng
+Version: @PACKAGE_VERSION@
+Release: 1
+Group: System Environment/Daemons
+License: GPL
+
+Requires: espeak-ng
+
+BuildRequires: espeak-ng-devel
+
+AutoProv: no
+AutoReq: yes
+
+Summary: eSpeak-NG speech driver for BRLTTY.
+%description -n brltty-speech-espeak-ng
+This package provides the eSpeak-NG speech driver for BRLTTY.
+
+Install this package if you would like to be able to use the
+eSpeak-NG text-to-speech engine.
+
+
 %package -n brltty-speech-festival
 Version: @PACKAGE_VERSION@
 Release: 1
@@ -513,6 +534,7 @@ rm -fr "${RPM_BUILD_ROOT}"
 %exclude %{_libdir}/brltty/libbrlttybba.so
 %exclude %{_libdir}/brltty/libbrlttybxw.so
 %exclude %{_libdir}/brltty/libbrlttyses.so
+%exclude %{_libdir}/brltty/libbrlttysen.so
 %exclude %{_libdir}/brltty/libbrlttysfl.so
 %exclude %{_libdir}/brltty/libbrlttysfv.so
 %exclude %{_libdir}/brltty/libbrlttyssd.so
@@ -540,6 +562,9 @@ rm -fr "${RPM_BUILD_ROOT}"
 
 %files -n brltty-speech-espeak
 %{_libdir}/brltty/libbrlttyses.so
+
+%files -n brltty-speech-espeak-ng
+%{_libdir}/brltty/libbrlttysen.so
 
 %files -n brltty-speech-festival
 %{_libdir}/brltty/libbrlttysfv.so

--- a/cfg-android
+++ b/cfg-android
@@ -89,6 +89,7 @@ export LDFLAGS="-Wl,--fix-cortex-a8"
    --with-braille-driver=-ba,-bg,-tt,-vr,al,at,bm,bn,ce,eu,fs,hm,ht,hw,ic,ir,md,mm,mt,np,pg,pm,sk,vo \
    \
    --without-espeak \
+   --without-espeak-ng \
    --without-flite \
    --without-mikropuhe \
    --without-speechd \

--- a/cfg-darwin
+++ b/cfg-darwin
@@ -25,6 +25,7 @@
    --without-libbraille \
    \
    --without-espeak \
+   --without-espeak-ng \
    --without-flite \
    --without-mikropuhe \
    --without-speechd \

--- a/cfg-dos
+++ b/cfg-dos
@@ -57,6 +57,7 @@ export LDFLAGS=""
    --with-braille-driver=-vr,all \
    \
    --without-espeak \
+   --without-espeak-ng \
    --without-flite \
    --without-mikropuhe \
    --without-speechd \

--- a/config.mk.in
+++ b/config.mk.in
@@ -370,6 +370,7 @@ SCREEN_DRIVER_LIBRARIES = @screen_driver_libraries@
 SCREEN_DRIVERS = @screen_drivers@
 
 ESPEAK_ROOT = @espeak_root@
+ESPEAK_NG_ROOT = @espeak_ng_root@
 FLITE_ROOT = @flite_root@
 FLITE_LANGUAGE = @flite_language@
 FLITE_LEXICON = @flite_lexicon@

--- a/configure.ac
+++ b/configure.ac
@@ -1746,6 +1746,10 @@ BRLTTY_ARG_DISABLE(
       BRLTTY_SPEECH_DRIVER([es], [eSpeak], [-L$(ESPEAK_ROOT)/lib -lespeak])
    ])
 
+   BRLTTY_IF_PACKAGE([eSpeak-NG], [espeak_ng], [include/espeak-ng/speak_lib.h], [dnl
+      BRLTTY_SPEECH_DRIVER([en], [eSpeak-NG], [-L$(ESPEAK_NG_ROOT)/lib -lespeak-ng])
+   ])
+
    BRLTTY_IF_PACKAGE([FestivalLite], [flite], [include/flite/flite.h], [dnl
       BRLTTY_ARG_REQUIRED(
          [flite-language], [LANGUAGE],


### PR DESCRIPTION
It is mostly a copy of the eSpeak driver, hence I put the following to `Drivers/Speech/eSpeak-NG/Makefile.in`:
`DRIVER_DEVELOPERS = Nicolas Pitre <nico@fluxnic.net>, Ondřej Lysoněk <olysonek@redhat.com>`