### PR TITLE
Fix BrlAPI socket creation when brltty is started from initrd

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -1723,6 +1723,8 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
 
     /* read-only, or not mounted yet, wait */
     approximateDelay(1000);
+    /* and potentially escape from initrd root */
+    chdir("/");
   }
 
   if (!adjustPermissions(BRLAPI_SOCKETPATH)) {


### PR DESCRIPTION
In that case the server would indefinitely try to create the socket
inside the initrd root. It needs to use chdir() to escape from it once
the real root is mounted.