### PR TITLE
AtSpi/AtSpi2: default to reading terminal only

### DIFF
--- a/Drivers/Screen/AtSpi/screen.c
+++ b/Drivers/Screen/AtSpi/screen.c
@@ -48,7 +48,7 @@ typedef enum {
 
 #include "scr_driver.h"
 
-static int typeText = 1, typeTerminal = 1, typeAll = 0;
+static int typeText = 0, typeTerminal = 1, typeAll = 0;
 static AccessibleText *curTerm;
 static Accessible *curFocus;
 

--- a/Drivers/Screen/AtSpi2/screen.c
+++ b/Drivers/Screen/AtSpi2/screen.c
@@ -254,7 +254,7 @@ processParameters_AtSpi2Screen (char **parameters) {
     }
   }
 
-  typeFlags[TYPE_TEXT] = 1;
+  typeFlags[TYPE_TEXT] = 0;
   typeFlags[TYPE_TERMINAL] = 1;
   typeFlags[TYPE_ALL] = 0;
   {


### PR DESCRIPTION
Brltty can not really be used alone to read a graphical desktop, Orca is
really needed to do any serious work, and it has much better support for
AtSpi.  Brltty however rocks in terminals, so it does make a lot of
sense to use it along Orca, but only for reading terminals.  It thus
makes sense to make this setup the default.