### PR TITLE
buildsys: fix cross-compilation

### DIFF
--- a/mk4build
+++ b/mk4build
@@ -112,7 +112,7 @@ fi
 
 sedScript="${outputName}.${sedExtension}"
 sed -n -e '
-s/^ *\([A-Za-z][A-Za-z_]*\) *=.*$/\1/
+s/^ *\([A-Za-z][A-Za-z0-9_]*\) *=.*$/\1/
 t found
 d
 :found


### PR DESCRIPTION
Some identifiers for includes and libs paths may contain digit, e.g.
X11_PACKAGE or ATSPI2_PACKAGE or GLIB2_PACKAGE...

Also detect those identifiers when doing cros-compilation, so that the
_FOR_BUILD variants are really created and do not clash with the target
variants.

Fixes:
    http://autobuild.buildroot.org/results/a37/a37782b3cfc1a96cc129db8fade20a36a7b2d470/build-end.log
    http://autobuild.buildroot.org/results/97e/97edc6a47d2140968e84b409cdc960604e5896f2/build-end.log
    [...]

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>