### PR TITLE
Fix linking error on mips64el

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -481,7 +481,12 @@ AC_CACHE_CHECK([for make relocatable object command], [brltty_cv_prog_make_objec
 case "${host_os}"
 in
    *)
-      brltty_cv_prog_make_object_relocatable="\$(LD) -r -o"
+      if test "${GCC}" = "yes"
+      then
+         brltty_cv_prog_make_object_relocatable="\$(CC) -shared -o"
+      else
+         brltty_cv_prog_make_object_relocatable="\$(LD) -r -o"
+      fi
       ;;
 esac])
 MKREL="${brltty_cv_prog_make_object_relocatable}"


### PR DESCRIPTION
Patch that was fixing build on mips64el was reverted:
https://github.com/brltty/brltty/commit/9e7d62c869d3c1cbe12dda8b0291a4692c193416

So fix the issue again, this time by checking if $(GCC) is available as
suggested by Arnout during review of buildroot patch:
https://patchwork.ozlabs.org/patch/972614

Fixes:
 - http://autobuild.buildroot.org/results/31f682838b3d3b2c7103b5c51f2aba0b89d4f630

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>