### PR TITLE
brltty-ttb: Add half-dots XCompose output format

### DIFF
--- a/Headers/datafile.h
+++ b/Headers/datafile.h
@@ -101,6 +101,10 @@ typedef struct {
 extern int parseCellsOperand (DataFile *file, ByteOperand *cells, const wchar_t *characters, int length);
 extern int getCellsOperand (DataFile *file, ByteOperand *cells, const char *description);
 
+unsigned char getLeftDots (unsigned char cell);
+unsigned char getRightDots (unsigned char cell);
+unsigned char getRightDotsToLeftDots (unsigned char cell);
+
 extern int writeDots (FILE *stream, unsigned char cell);
 extern int writeDotsCell (FILE *stream, unsigned char cell);
 extern int writeDotsCells (FILE *stream, const unsigned char *cells, size_t count);

--- a/Programs/datafile.c
+++ b/Programs/datafile.c
@@ -694,18 +694,40 @@ getCellsOperand (DataFile *file, ByteOperand *cells, const char *description) {
   return 0;
 }
 
+#define DOT(n) (1 << ((n)-1))
+unsigned char
+getLeftDots (unsigned char cell) {
+  return cell & (DOT(1) | DOT(2) | DOT(3) | DOT(7));
+}
+
+unsigned char
+getRightDots (unsigned char cell) {
+  return cell & (DOT(4) | DOT(5) | DOT(6) | DOT(8));
+}
+
+unsigned char
+getRightDotsToLeftDots (unsigned char cell) {
+  unsigned char ret = 0;
+  if (cell & DOT(4)) ret |= DOT(1);
+  if (cell & DOT(5)) ret |= DOT(2);
+  if (cell & DOT(6)) ret |= DOT(3);
+  if (cell & DOT(8)) ret |= DOT(7);
+  return ret;
+}
+
 int
 writeDots (FILE *stream, unsigned char cell) {
   unsigned int dot;
 
   for (dot=1; dot<=BRL_DOT_COUNT; dot+=1) {
-    if (cell & (1 << (dot - 1))) {
+    if (cell & DOT(dot)) {
       if (fprintf(stream, "%u", dot) == EOF) return 0;
     }
   }
 
   return 1;
 }
+#undef DOT
 
 int
 writeDotsCell (FILE *stream, unsigned char cell) {


### PR DESCRIPTION
This can be used for typing braille with one hand by pressing dots 1, 2, 3,
7 keys twice, the first time for dots 1, 2, 3, 7, and the second time for
dots 4, 5, 6, 8.