### PR TITLE
Start API server during initialization

### DIFF
--- a/Programs/config.c
+++ b/Programs/config.c
@@ -1493,7 +1493,6 @@ initializeBrailleDriver (const char *code, int verify) {
         if (oldPreferencesFile) {
           logMessage(LOG_INFO, "%s: %s", gettext("Old Preferences File"), oldPreferencesFile);
 
-          startApiServer();
           api.link();
 
           return 1;
@@ -2778,6 +2777,8 @@ brlttyStart (void) {
     }
   }
 #endif /* ENABLE_SPEECH_SUPPORT */
+
+  startApiServer();
 
   if (!opt_verify) notifyServiceReady();
 

--- a/Programs/xbrlapi.c
+++ b/Programs/xbrlapi.c
@@ -199,6 +199,13 @@ static int tobrltty_init(char *auth, char *host) {
     return 0;
   }
 
+  if (x == 0)
+  {
+    /* Braille device not initialized yet */
+    api_cleanExit();
+    return 0;
+  }
+
   brlapi_setExceptionHandler(exception_handler);
   return 1;
 }


### PR DESCRIPTION
instead of waiting for driver construction. This allows clients, notably
xbrlapi, to know that brltty is present, but the device is not plugged in,
and should thus stay around, ready to start working when the device is
plugged in. When brltty is not present, they will know it from the refused
connexion, and tell the user about it and exit.