### PR TITLE
brltty-ttb: Add alternated half xcompose files

### DIFF
--- a/Headers/brl_dots.h
+++ b/Headers/brl_dots.h
@@ -80,11 +80,31 @@ getRightDotsToLeftDots (BrlDots cell) {
 }
 
 static inline BrlDots
+getRightDotsToLeftDotsAlt (BrlDots cell) {
+  unsigned char ret = 0;
+  if (cell & BRL_DOT_4) ret |= BRL_DOT_3;
+  if (cell & BRL_DOT_5) ret |= BRL_DOT_2;
+  if (cell & BRL_DOT_6) ret |= BRL_DOT_1;
+  if (cell & BRL_DOT_8) ret |= BRL_DOT_7;
+  return ret;
+}
+
+static inline BrlDots
 getLeftDotsToRightDots (BrlDots cell) {
   unsigned char ret = 0;
   if (cell & BRL_DOT_1) ret |= BRL_DOT_4;
   if (cell & BRL_DOT_2) ret |= BRL_DOT_5;
   if (cell & BRL_DOT_3) ret |= BRL_DOT_6;
+  if (cell & BRL_DOT_7) ret |= BRL_DOT_8;
+  return ret;
+}
+
+static inline BrlDots
+getLeftDotsToRightDotsAlt (BrlDots cell) {
+  unsigned char ret = 0;
+  if (cell & BRL_DOT_1) ret |= BRL_DOT_6;
+  if (cell & BRL_DOT_2) ret |= BRL_DOT_5;
+  if (cell & BRL_DOT_3) ret |= BRL_DOT_4;
   if (cell & BRL_DOT_7) ret |= BRL_DOT_8;
   return ret;
 }

--- a/Programs/brltty-ttb.c
+++ b/Programs/brltty-ttb.c
@@ -842,6 +842,33 @@ error:
 }
 
 static int
+writeCharacter_lefthalfalt_XCompose (
+  FILE *file, wchar_t character, unsigned char dots,
+  const unsigned char *byte, int isPrimary, const void *_data
+) {
+  if (isPrimary) {
+    unsigned char leftDots = getLeftDots(dots);
+    unsigned char rightDots = getRightDotsToLeftDotsAlt(dots);
+
+    if (!writeCharacter_half_XCompose(file, character, leftDots, rightDots)) return 0;
+  }
+
+  return 1;
+}
+
+static int
+writeTable_lefthalfalt_XCompose (
+  const char *path, FILE *file, TextTableData *ttd, const void *data
+) {
+  if (!writeHeaderComment(file, writeHashComment)) goto error;
+  if (!writeCharacters(file, ttd, writeCharacter_lefthalfalt_XCompose, NULL)) goto error;
+  return 1;
+
+error:
+  return 0;
+}
+
+static int
 writeCharacter_righthalf_XCompose (
   FILE *file, wchar_t character, unsigned char dots,
   const unsigned char *byte, int isPrimary, const void *_data
@@ -862,6 +889,33 @@ writeTable_righthalf_XCompose (
 ) {
   if (!writeHeaderComment(file, writeHashComment)) goto error;
   if (!writeCharacters(file, ttd, writeCharacter_righthalf_XCompose, NULL)) goto error;
+  return 1;
+
+error:
+  return 0;
+}
+
+static int
+writeCharacter_righthalfalt_XCompose (
+  FILE *file, wchar_t character, unsigned char dots,
+  const unsigned char *byte, int isPrimary, const void *_data
+) {
+  if (isPrimary) {
+    unsigned char leftDots = getLeftDotsToRightDotsAlt(dots);
+    unsigned char rightDots = getRightDots(dots);
+
+    if (!writeCharacter_half_XCompose(file, character, leftDots, rightDots)) return 0;
+  }
+
+  return 1;
+}
+
+static int
+writeTable_righthalfalt_XCompose (
+  const char *path, FILE *file, TextTableData *ttd, const void *data
+) {
+  if (!writeHeaderComment(file, writeHashComment)) goto error;
+  if (!writeCharacters(file, ttd, writeCharacter_righthalfalt_XCompose, NULL)) goto error;
   return 1;
 
 error:
@@ -1034,8 +1088,16 @@ static const FormatEntry formatEntries[] = {
     .write = writeTable_lefthalf_XCompose,
   },
 
+  { .name = "lefthalfalt-XCompose",
+    .write = writeTable_lefthalfalt_XCompose,
+  },
+
   { .name = "righthalf-XCompose",
     .write = writeTable_righthalf_XCompose,
+  },
+
+  { .name = "righthalfalt-XCompose",
+    .write = writeTable_righthalfalt_XCompose,
   },
 
   { .name = "jbt",


### PR DESCRIPTION
Some one-handed people are used to having to move their hand between
left and right part. Not having to move the hand is convenient, but they
are used to using the same key for dot1 and dot6, dot2 and dot5, dot3
and dot4, instead of dot1/dot4, dot2/dot4, dot3/dot6.