### PR TITLE
Reduce log level of API client connection

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -2406,7 +2406,7 @@ THREAD_FUNCTION(runServer) {
 #ifdef __MINGW32__
         }
 #endif /* __MINGW32__ */
-        logMessage(LOG_NOTICE, "BrlAPI connection fd=%"PRIfd" accepted: %s", resfd, source);
+        logMessage(LOG_INFO, "BrlAPI connection fd=%"PRIfd" accepted: %s", resfd, source);
 
         if (unauthConnections >= UNAUTH_LIMIT) {
           writeError(resfd, BRLAPI_ERROR_CONNREFUSED);


### PR DESCRIPTION
To avoid spamming system logs when Orca tries to reconnect periodically
until a braille device is connected.