### PR TITLE
python: respect V=1 make parameter

### DIFF
--- a/Bindings/Python/Makefile.in
+++ b/Bindings/Python/Makefile.in
@@ -38,13 +38,18 @@ PYTHON_PREFIX =
 PYTHON_MODULE = $(API_NAME)
 PYTHON_API = $(PYTHON_MODULE).$(LIB_EXT)
 
+V_setup_  = $(V_setup_0)
+V_setup_0 = --quiet
+V_setup_1 = --verbose
+V_setup   = $(V_setup_$(V))
+
 all: $(PYTHON_API)
 
 $(PYTHON_API): brlapi.auto.c $(API_HDRS) brlapi
-	set -- --quiet build --build-temp .; \
+	set -- $(V_setup) build --build-temp .; \
 	[ "@host_os@" != "mingw32" ] || set -- "$${@}" --compiler mingw32; \
 	"$(PYTHON)" ./setup.py "$${@}"
-	[ "@host_os@" != "mingw32" ] || "$(PYTHON)" ./setup.py --quiet bdist_wininst --skip-build
+	[ "@host_os@" != "mingw32" ] || "$(PYTHON)" ./setup.py $(V_setup) bdist_wininst --skip-build
 
 brlapi.auto.c: $(SRC_DIR)/brlapi.pyx $(SRC_DIR)/c_brlapi.pxd constants.auto.pyx
 	"$(CYTHON)" -$(PYTHON_VERSION) -I. -o $@ $(SRC_DIR)/brlapi.pyx
@@ -58,7 +63,7 @@ doc: $(PYTHON_API)
 INSTALLED_FILES = installed-files
 
 install: all
-	set -- --quiet install --skip-build --record "$(INSTALLED_FILES)"; \
+	set -- $(V_setup) install --skip-build --record "$(INSTALLED_FILES)"; \
 	[ -z "$(PYTHON_DESTDIR)" ] || set -- "$${@}" --root "$(PYTHON_DESTDIR)"; \
 	[ -z "$(PYTHON_PREFIX)" ] || set -- "$${@}" --prefix "$(PYTHON_PREFIX)"; \
 	"$(PYTHON)" ./setup.py "$${@}"


### PR DESCRIPTION
By passing --quiet vs --verbose to python setup.py, we can respect the
largely-used V=1 make parameter, so e.g. Debian build logs contain all
build details.