### PR TITLE
mk4build: also pass PKG_CONFIG_FOR_BUILD to the native configure

### DIFF
--- a/mk4build
+++ b/mk4build
@@ -54,7 +54,7 @@ then
    needTemporaryDirectory
    objectExtension="build.${objectExtension}"
 
-   for variable in CC  CFLAGS CXX CXXFLAGS LDFLAGS LDLIBS
+   for variable in CC  CFLAGS CXX CXXFLAGS LDFLAGS LDLIBS PKG_CONFIG
    do
       getVariable "${variable}_FOR_BUILD" value
       setVariable "${variable}" "${value}"


### PR DESCRIPTION
In commit 0414ad2b4e8978a14343d920a5a1f11da892eaf3, mk4build was
modified to pass a number of *_FOR_BUILD variables down to the
configure script called for building the native tools.

However, this configure script also uses the pkg-config tool, and the
pkg-config to use for the native build and the cross build may be
different, so let's also pass PKG_CONFIG_FOR_BUILD down to the
sub-configure, as PKG_CONFIG, following the same logic as the other
variables.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>