### PR TITLE
brlapi: Check that we do not have too many files open

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -3670,6 +3670,16 @@ THREAD_FUNCTION(runServer) {
             continue;
           }
 
+#ifndef __MINGW32__
+          if (resfd >= FD_SETSIZE) {
+            /* Will not be able to call select() on this */
+            setErrno(EMFILE);
+            logMessage(LOG_WARNING,"accept(%"PRIfd"): %s",socketInfo[i].fd,strerror(errno));
+            continue;
+          }
+
+#endif
+
           formatAddress(source, sizeof(source), &addr, addrlen);
 #ifdef __MINGW32__
         }


### PR DESCRIPTION
FD_SET would otherwise just crash, instead of returning an error.