### PR TITLE
Fine-tune xbrlapi+brltty startup

### DIFF
--- a/Autostart/X11/60xbrlapi.in
+++ b/Autostart/X11/60xbrlapi.in
@@ -1,2 +1,0 @@
-program="@program_directory@/xbrlapi"
-[ -x "${program}" ] && "${program}" 2>/dev/null &

--- a/Autostart/X11/90brltty.in
+++ b/Autostart/X11/90brltty.in
@@ -1,2 +1,0 @@
-program="@program_directory@/brltty"
-[ -x "${program}" ] && "${program}" -b ba -s no -x a2 -N 2>/dev/null &

--- a/Autostart/X11/90xbrlapi.in
+++ b/Autostart/X11/90xbrlapi.in
@@ -1,0 +1,12 @@
+program_directory="@program_directory@"
+xbrlapi="$program_directory/xbrlapi"
+brltty="$program_directory/brltty"
+
+if [ -x "${xbrlapi}" ]; then
+  if "${xbrlapi}" 2>/dev/null ; then
+    # xbrlapi could connect to BrlAPI, try to start brltty with AtSpi2 driver.
+    if [ -x "${brltty}" ]; then
+      "${brltty}" -b ba -s no -x a2 -N 2>/dev/null
+    fi
+  fi
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -2019,8 +2019,7 @@ AC_OUTPUT([
    Bindings/Lisp/brlapi_config.lisp
    Bindings/Python/setup.py
    Autostart/Systemd/brltty@.service
-   Autostart/X11/60xbrlapi
-   Autostart/X11/90brltty
+   Autostart/X11/90xbrlapi
    Android/Application/res/values/configured.xml:Android/Application/res.strings.in
    ${brltty_make_files}
 ])


### PR DESCRIPTION
xbrlapi now starts in the background by default after checking whether
it could connect to brlapi.

We can thus use its result to determine whether to start brltty with
the AtSpi2 driver automatically.