### PR TITLE
Request extended standards on windows too

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -309,7 +309,10 @@ in
       brltty_prog_cc_sysflags="-D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE -D_OSF_SOURCE"
       ;;
    cygwin*)
-      brltty_prog_cc_sysflags="-D_XOPEN_SOURCE_EXTENDED"
+      brltty_prog_cc_sysflags="-D_XOPEN_SOURCE_EXTENDED -D_GNU_SOURCE"
+      ;;
+   mingw*)
+      brltty_prog_cc_sysflags="-D_XOPEN_SOURCE_EXTENDED -D_GNU_SOURCE"
       ;;
    *)
       brltty_prog_cc_sysflags=""


### PR DESCRIPTION
This notably fixes getting mempcpy, which would otherwise be detected by
configure, but its prototype not taken from system headers.