### PR TITLE
brlapi: Make server have enough buffer for sending/receiving a packet

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -3042,7 +3042,10 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
   if ((fd = CreateNamedPipe(path,
 	  PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
 	  PIPE_TYPE_BYTE | PIPE_READMODE_BYTE,
-	  PIPE_UNLIMITED_INSTANCES, 0, 0, 0, NULL)) == INVALID_HANDLE_VALUE) {
+	  PIPE_UNLIMITED_INSTANCES,
+	  BRLAPI_MAXPACKETSIZE + sizeof(brlapi_header_t),
+	  BRLAPI_MAXPACKETSIZE + sizeof(brlapi_header_t),
+	  0, NULL)) == INVALID_HANDLE_VALUE) {
     if (GetLastError() != ERROR_CALL_NOT_IMPLEMENTED)
       logWindowsSystemError("CreateNamedPipe");
     goto out;


### PR DESCRIPTION
On Windows, the default named pipe buffer size is actually very small.
We have to tell the OS which minimum size we want. Otherwise we can get
in a situation where both the server and the client are trying to send
data, but none of them is reading each other's output, thus a deadlock.

Making the output buffer large enough allows the server to make sure
that it can write its packets to the client without blocking, and get
back to reading data from the client.