### PR TITLE
libbrlapi: Automatically get VT nr from logind

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -254,6 +254,9 @@ extern "C" {
 /* Define this if the function shl_load is available. */
 #undef HAVE_SHL_LOAD
 
+/* Define this if the function sd_session_get_vt is available in libsystemd. */
+#undef HAVE_SD_SESSION_GET_VT
+
 /* Define this to be a string containing the copyright notice. */
 #undef PACKAGE_COPYRIGHT
 

--- a/configure.ac
+++ b/configure.ac
@@ -1230,6 +1230,17 @@ in
       ;;
 esac
 
+BRLTTY_HAVE_PACKAGE([systemd], [libsystemd], [
+    brltty_libs_save="${LIBS}"
+    LIBS="${LIBS} ${systemd_libs}"
+    AC_CHECK_FUNC([sd_session_get_vt], [
+      AC_DEFINE([HAVE_SD_SESSION_GET_VT], [1],
+                [Define this if the function sd_session_get_vt is available in libsystemd.])
+      api_libraries="${api_libraries} ${systemd_libs}"
+    ])
+    LIBS="${brltty_libs_save}"
+])
+
 BRLTTY_ARG_PACKAGE([params], [boot parameters], [], [dnl
    linux*)
       params_package="linux"


### PR DESCRIPTION
Notably on gnome with Wayland, XDG_VTNR may not be getting defined. We
can however just directly ask logind which VT our process is running on.