### PR TITLE
brlapi: Also listen on IPv6 by default

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -4376,9 +4376,9 @@ int api_startServer(BrailleDisplay *brl, char **parameters)
 
   char *hosts =
 #if defined(PF_LOCAL)
-	":0+127.0.0.1:0"
+	":0+127.0.0.1:0+::1:0"
 #else /* PF_LOCAL */
-	"127.0.0.1:0"
+	"127.0.0.1:0+::1:0"
 #endif /* PF_LOCAL */
 	;
 


### PR DESCRIPTION
So that forwarding TCP port localhost:4101 also works on systems where
localhost resolve to ::1 too.