### PR TITLE
xbrlapi: do not print the root window name

### DIFF
--- a/Programs/xbrlapi.c
+++ b/Programs/xbrlapi.c
@@ -563,10 +563,10 @@ static int grabWindows(Window win,int level) {
 }
 
 static void setName(const struct window *window) {
-  if (!window->wm_name)
-    if (window->win==window->root) api_setName("root");
-    else api_setName("unknown");
-  else api_setName(window->wm_name);
+  if (!window->wm_name) {
+    if (window->win!=window->root)
+      api_setName("window without name");
+  } else api_setName(window->wm_name);
 }
 
 static void setFocus(Window win) {


### PR DESCRIPTION
The root window gets focus transiently when the window manager switches
windows etc. It is not generally useful to the user to get notified about
it, and is mostly perceived as glitches, so better only show names of real
windows.