### PR TITLE
Handle OCaml safe-string

### DIFF
--- a/Bindings/OCaml/brlapi_stubs.c
+++ b/Bindings/OCaml/brlapi_stubs.c
@@ -144,7 +144,7 @@ CAMLprim value brlapiml_errorCode_of_error(value camlError)
 /* Raises the Brlapi_error exception */
 static void raise_brlapi_error(void)
 {
-  static value *exception = NULL;
+  static const value *exception = NULL;
   CAMLparam0();
   CAMLlocal1(res);
   if (exception==NULL) exception = caml_named_value("Brlapi_error");
@@ -159,7 +159,7 @@ static void raise_brlapi_error(void)
 /* Raises Brlapi_exception */
 static void BRLAPI_STDCALL raise_brlapi_exception(int err, brlapi_packetType_t type, const void *packet, size_t size)
 {
-  static value *exception = NULL;
+  static const value *exception = NULL;
   int i;
   CAMLparam0();
   CAMLlocal2(str, res);
@@ -309,13 +309,13 @@ CAMLprim value brlapiml_write(value handle, value writeArguments)
   wa.displayNumber = Val_int(Field(writeArguments, 0));
   wa.regionBegin = Val_int(Field(writeArguments, 1));
   wa.regionSize = Val_int(Field(writeArguments, 2));
-  wa.text = String_val(Field(writeArguments, 3));
+  wa.text = &Byte(String_val(Field(writeArguments, 3)), 0);
   packDots(Field(writeArguments, 4), andMask, andSize);
   wa.andMask = andMask;
   packDots(Field(writeArguments, 5), orMask, orSize);
   wa.orMask = orMask;
   wa.cursor = Val_int(Field(writeArguments, 6));
-  wa.charset = String_val(Field(writeArguments, 7));
+  wa.charset = &Byte(String_val(Field(writeArguments, 7)), 0);
   brlapiCheckError(write, &wa);
   CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
Since OCaml 4.10 strings are immutable by default.

This affects the String_val() API, which returns a 'const char *'.
This affects the caml_named_value() API, which returns a 'const char *'.

Add backward compatible change to handle -safe-string and -unsafe-string.

ocamlc.opt -ccopt "-I. -I. -I./../../Programs -I../../Programs -I../../Headers -I./../.. -I../..  -I/usr/lib/jvm/java/include -I/usr/lib/jvm/java/include/linux  -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=2 -D_BSD_SOURCE -D_XOPEN_SOURCE=500 -D_XOPEN_SOURCE_EXTENDED -D_GNU_SOURCE -DHAVE_CONFIG_H -fomit-frame-pointer -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -Werror=return-type -flto=auto -std=gnu99 -Wall -Werror=format-security" -I ./../../Programs -I ../../Programs -c ./brlapi_stubs.c
./brlapi_stubs.c: In function 'raise_brlapi_error':
./brlapi_stubs.c:150:34: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  150 |   if (exception==NULL) exception = caml_named_value("Brlapi_error");
      |                                  ^
./brlapi_stubs.c: In function 'raise_brlapi_exception':
./brlapi_stubs.c:168:34: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  168 |   if (exception==NULL) exception = caml_named_value("Brlapi_exception");
      |                                  ^
./brlapi_stubs.c: In function 'brlapiml_write':
./brlapi_stubs.c:312:11: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  312 |   wa.text = String_val(Field(writeArguments, 3));
      |           ^
./brlapi_stubs.c:318:14: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  318 |   wa.charset = String_val(Field(writeArguments, 7));
      |              ^
cc1: some warnings being treated as errors
make[2]: *** [Makefile:104: brlapi_stubs.o] Error 2

Signed-off-by: Olaf Hering <olaf@aepfle.de>