### PR TITLE
atspi2: Fix ignoring invalid data

### DIFF
--- a/Drivers/Screen/AtSpi2/a2_screen.c
+++ b/Drivers/Screen/AtSpi2/a2_screen.c
@@ -673,7 +673,7 @@ static void restartTerm(const char *sender, const char *path) {
 	logMessage(LOG_ERR,"unterminated sequence %s",c);
       else if (len==-1)
 	logSystemError("mbrlen");
-      curRowLengths[i] = (len = -1) + (d != NULL);
+      curRowLengths[i] = (len = 0) + (d != NULL);
     }
     curRows[i] = malloc((len + (d!=NULL)) * sizeof(*curRows[i]));
     e = c;


### PR DESCRIPTION
When we get invalid utf-8 data from getText or getName that contains \n,
we were previously setting length to -1, and later on curRows[i][len]='\n'
would thus use a negative offset. Setting the length to 0 allows to just
drop the invalid text.