### PR TITLE
brlapi: Fix backspace synthesis in xbrlapi

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -4109,11 +4109,9 @@ static int api__handleCommand(int command) {
       if (!cmdBrlttyToBrlapi(&alternate, command, 0)) {
 	logMessage(LOG_CATEGORY(SERVER_EVENTS), "command %08x could not be converted to BrlAPI without retainDots", command);
       } else {
-	if (alternate != code) {
-	  logMessage(LOG_CATEGORY(SERVER_EVENTS), "command %08x -> client code %016"BRLAPI_PRIxKEYCODE, command, alternate);
-	  c = whoGetsKey(&ttys, alternate, BRL_COMMANDS, 0);
-	  if (c) code = alternate;
-	}
+	logMessage(LOG_CATEGORY(SERVER_EVENTS), "command %08x -> client code %016"BRLAPI_PRIxKEYCODE, command, alternate);
+	c = whoGetsKey(&ttys, alternate, BRL_COMMANDS, 0);
+	if (c) code = alternate;
       }
     }
 


### PR DESCRIPTION
Even if the alternate code without retaindot is the same as the code
with retaindot, we need to call whoGetsKey. Otherwise xbrlapi does not
get backspace keycodes: they produce the same keycode with/without
retaindot, but since xbrlapi sets retaindot to 0, it would not get them
from the first call.