### PR TITLE
Programs/pgmprivs_linux.c: fix build with gcc < 5

### DIFF
--- a/Programs/pgmprivs_linux.c
+++ b/Programs/pgmprivs_linux.c
@@ -2215,13 +2215,15 @@ typedef enum {
   PARM_USER,
 } Parameters;
 
-const char *const *
-getPrivilegeParameterNames (void) {
-  static const char *const names[] = NULL_TERMINATED_STRING_ARRAY(
+
+static const char *const *const pgmprivs_names =
+  NULL_TERMINATED_STRING_ARRAY(
     "path", "scfmode", "shell", "user"
   );
 
-  return names;
+const char *const *
+getPrivilegeParameterNames (void) {
+  return pgmprivs_names;
 }
 
 const char *


### PR DESCRIPTION
Build with gcc < 5 is broken since version 6.2 and https://github.com/brltty/brltty/commit/8ce262f2c15f10a40d9cbae0b3c88b466970a055:

```
./pgmprivs_linux.c: In function 'getPrivilegeParameterNames':
./pgmprivs_linux.c:2220:3: error: array initialized from non-constant array expression
   static const char *const names[] = NULL_TERMINATED_STRING_ARRAY(
   ^
```

Build was partially fixed since https://github.com/brltty/brltty/commit/8ae78dd560d00c5074158f90be5ac8dac80183db but it forgot to update pgmprivs_linux.c

Fixes:
 - http://autobuild.buildroot.org/results/58afeb50a0ecdb8b527d7c9946bcae290b79b055

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>