### PR TITLE
xbrlapi: Use sig_atomic_t for signal-modified variable

### DIFF
--- a/Programs/xbrlapi.c
+++ b/Programs/xbrlapi.c
@@ -356,7 +356,7 @@ static Atom netWmNameAtom, utf8StringAtom;
 
 static XSelData xselData;
 
-static volatile int grabFailed;
+static volatile sig_atomic_t grabFailed;
 
 #ifdef HAVE_ICONV_H
 iconv_t utf8Conv = (iconv_t)(-1);


### PR DESCRIPTION
In practice int is usually fine, but better document that this is indeed
a variable to be written by the handler and read by the main thread.