### PR TITLE
brlapi: obey the braille typing mode user preference

### DIFF
--- a/Programs/apitest.c
+++ b/Programs/apitest.c
@@ -385,7 +385,7 @@ static void testParameters(void)
   if (brlapi_watchParameter(BRLAPI_PARAM_RETAIN_DOTS, 0, BRLAPI_PARAMF_LOCAL, brailleRetainDotsChanged, NULL, NULL, 0) == 0) {
     brlapi_perror("watchParameter");
   }
-  val = 0;
+  val = 1;
   printf("setting retain dots parameter to %d\n", val);
   if (brlapi_setParameter(BRLAPI_PARAM_RETAIN_DOTS, 0, BRLAPI_PARAMF_LOCAL, &val, sizeof(val)) < 0) {
     brlapi_perror("setParameter");
@@ -394,7 +394,7 @@ static void testParameters(void)
     brlapi_perror("getParameter");
   }
   printf("retain dots now %d\n", val);
-  val = 1;
+  val = 0;
   printf("setting retain dots parameter to %d\n", val);
   if (brlapi_setParameter(BRLAPI_PARAM_RETAIN_DOTS, 0, BRLAPI_PARAMF_LOCAL, &val, sizeof(val)) < 0) {
     brlapi_perror("setParameter");

--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -659,7 +659,7 @@ static Connection *createConnection(FileDescriptor fd, time_t currentTime)
   }
 
   c->how = 0;
-  c->retainDots = 1;
+  c->retainDots = 0;
   c->acceptedKeys = NULL;
   c->upTime = currentTime;
   c->brailleWindow.text = NULL;

--- a/Programs/cmd_brlapi.c
+++ b/Programs/cmd_brlapi.c
@@ -23,6 +23,8 @@
 #include "cmd_brlapi.h"
 #include "brl_cmds.h"
 #include "ttb.h"
+#include "prefs.h"
+#include "brl_types.h"
 
 #ifdef ENABLE_API
 static brlapi_keyCode_t
@@ -42,7 +44,12 @@ cmdBrlttyToBrlapi (brlapi_keyCode_t *code, int command, int retainDots) {
       break;
 
     case BRL_CMD_BLK(PASSDOTS):
+      /* The client may prefer dots */
       if (retainDots) goto doDefault;
+
+      /* The user may prefer dots */
+      if (prefs.brailleTypingMode == BRL_TYPING_DOTS) goto doDefault;
+
       *code = cmdWCharToBrlapi(convertDotsToCharacter(textTable, arg));
       break;
 


### PR DESCRIPTION
This makes brlapi clients not get dots patterns by default, and rather just
obey the user preference.