### PR TITLE
brlapi: Fix documentation for brlapi_enterTtyMode

### DIFF
--- a/Documents/Manual-BrlAPI/English/BrlAPI.sgml
+++ b/Documents/Manual-BrlAPI/English/BrlAPI.sgml
@@ -1283,8 +1283,6 @@ or raw mode. The client can send either of these types of packet:
 no power on it any more, masked keys excepted. It's up to the client to manage
 display and keypresses. For this, it can send either of these types of packet:
   <itemize>
-  <item><tt/BRLAPI_PACKET_ENTERTY/MODE to switch to another tty, but how key presses
-  should be sent mustn't change,
   <item><tt/BRLAPI_PACKET_LEAVETTYMODE/ to leave tty handling mode and go back to
   normal mode,
   <item><tt/BRLAPI_PACKET_IGNOREKEYRANGE/ and <tt/BRLAPI_PACKET_ACCEPTKEYRANGE/ to mask and unmask keys,

--- a/Programs/brlapi.h.in
+++ b/Programs/brlapi.h.in
@@ -429,11 +429,14 @@ int BRLAPI_STDCALL brlapi__getDisplaySize(brlapi_handle_t *handle, unsigned int 
  * key presses. NULL or "" means BRLTTY commands are required,
  * whereas a driver name means that driver-specific keycodes are expected.
  *
+ * \return the used tty number on success, -1 on error
+ *
  * WINDOWPATH and WINDOWID should be propagated when running remote applications
  * via ssh, for instance, along with BRLAPI_HOST and the authorization key (see
  * SendEnv in ssh_config(5) and AcceptEnv in sshd_config(5))
  *
- * \return the used tty number on success, -1 on error
+ * Once brlapi_enterTtyMode() is called, brlapi_leaveTtyMode() has to be called
+ * before calling brlapi_enterTtyMode() again.
  *
  * \sa brlapi_leaveTtyMode() brlapi_readKey()
  */


### PR DESCRIPTION
Once brlapi_enterTtyMode is called, brlapi_enterTtyMode cannot be called
until brlapi_leaveTtyMode is called.