### PR TITLE
brlapi_client: Add thead-safe brlapi_strerror_r

### DIFF
--- a/Bindings/OCaml/brlapi_stubs.c
+++ b/Bindings/OCaml/brlapi_stubs.c
@@ -493,7 +493,10 @@ CAMLprim value brlapiml_strerror(value camlError)
   error.libcerrno = Int_val(Field(camlError,1));
   error.gaierrno = Int_val(Field(camlError,2));
   error.errfun = String_val(Field(camlError,3));
-  CAMLreturn(caml_copy_string(brlapi_strerror(&error)));
+  size_t size = brlapi_strerror_r(&error, NULL, 0);
+  char buf[size+1];
+  brlapi_strerror_r(&error, buf, sizeof(buf));
+  CAMLreturn(caml_copy_string(buf));
 }
 
 /* Function : setExceptionHandler */

--- a/Bindings/Python/brlapi.pyx
+++ b/Bindings/Python/brlapi.pyx
@@ -237,6 +237,8 @@ class OperationError(Exception):
 
 	def __str__(self):
 		cdef c_brlapi.brlapi_error_t error
+		cdef c_brlapi.size_t size
+		cdef char *buf
 		if self.exception:
 			return self.exception
 		error.brlerrno = self.brlerrno
@@ -244,7 +246,12 @@ class OperationError(Exception):
 		error.gaierrno = self.gaierrno
 		str = self.errfun
 		error.errfun = str
-		return c_brlapi.brlapi_strerror(&error)
+		size = c_brlapi.brlapi_strerror_r(&error, NULL, 0)
+		buf = <char*>c_brlapi.malloc(size+1)
+		c_brlapi.brlapi_strerror_r(&error, buf, size+1)
+		ret = buf.decode("ASCII", errors="replace")
+		c_brlapi.free(buf)
+		return ret
 
 class ConnectionError(OperationError):
 	"""Error while connecting to BrlTTY"""

--- a/Bindings/Python/c_brlapi.pxd
+++ b/Bindings/Python/c_brlapi.pxd
@@ -133,7 +133,7 @@ cdef extern from "Programs/brlapi.h":
 	brlapi_paramCallbackDescriptor_t)
 
 	brlapi_error_t* brlapi_error_location()
-	char* brlapi_strerror(brlapi_error_t*)
+	size_t brlapi_strerror_r(brlapi_error_t*, char *buf, size_t buflen)
 	brlapi_keyCode_t BRLAPI_KEY_MAX
 	brlapi_keyCode_t BRLAPI_KEY_FLAGS_MASK
 	brlapi_keyCode_t BRLAPI_KEY_TYPE_MASK

--- a/Bindings/Tcl/bindings.c
+++ b/Bindings/Tcl/bindings.c
@@ -91,9 +91,12 @@ setByteArrayResult (Tcl_Interp *interp, const unsigned char *bytes, int count) {
 
 static void
 setBrlapiError (Tcl_Interp *interp) {
-  const char *text = brlapi_strerror(&brlapi_error);
+  size_t size = brlapi_strerror_r(&brlapi_error, NULL, 0);
+  char text[size+1];
   const char *name;
   int number;
+
+  brlapi_strerror_r(&brlapi_error, text, sizeof(text));
 
   switch (brlapi_error.brlerrno) {
     case BRLAPI_ERROR_LIBCERR:
@@ -125,15 +128,7 @@ setBrlapiError (Tcl_Interp *interp) {
 
   Tcl_Obj *result = Tcl_GetObjResult(interp);
   Tcl_SetStringObj(result, "BrlAPI error: ", -1);
-  size_t length = strlen(text);
-
-  while (length > 0) {
-    size_t end = length - 1;
-    if (text[end] != '\n') break;
-    length = end;
-  }
-
-  Tcl_AppendToObj(result, text, length);
+  Tcl_AppendToObj(result, text, -1);
 }
 
 #define TEST_BRLAPI_OK(expression) \

--- a/Programs/brlapi.h.in
+++ b/Programs/brlapi.h.in
@@ -1354,9 +1354,29 @@ extern const char *brlapi_errfun;
  *
  * brlapi_strerror() returns the plain error message corresponding to its
  * argument. Since the message is a constant string, the application must not
- * free it.
+ * free it. Also, this makes it unsafe in threaded environments,
+ * brlapi_strerror_r() should be used instead in that case.
  */
 const char * BRLAPI_STDCALL brlapi_strerror(const brlapi_error_t *error);
+
+/* brlapi_strerror_r */
+/** Store plain error message
+ *
+ * brlapi_strerror_r() stores the plain error message corresponding to its
+ * \p error argument. \p buflen has to be set to the size of \p buf, and
+ * brlapi_strerror_r() will store at most \p buflen bytes in \p buf. If \p
+ * buflen is not large enough for the whole error message, it will be truncated,
+ * but a trailing \0 character will still be set at buf[buflen-1].
+ *
+ * \returns the number of characters that should have been stored in \p buf
+ * (without the trailing \0 character). A value greater or equal to \p buflen
+ * thus means that the output was truncated.
+ *
+ * If \p buflen is set to 0, \p buf can be set to NULL, and brlapi_strerror_r
+ * will thus only return the number of characters that would have been stored
+ * (without the trailing \0 character).
+ */
+size_t BRLAPI_STDCALL brlapi_strerror_r(const brlapi_error_t *error, char *buf, size_t buflen);
 
 /** Type for packet type. Only unsigned can cross networks, 32bits */
 typedef uint32_t brlapi_packetType_t;


### PR DESCRIPTION
And make bindings use it instead of brlapi_strerror.