### PR TITLE
brlapi: Allow writes that fill up to the end of the display

### DIFF
--- a/Bindings/Python/c_brlapi.pxd
+++ b/Bindings/Python/c_brlapi.pxd
@@ -38,7 +38,7 @@ cdef extern from "Programs/brlapi.h":
 	ctypedef struct brlapi_writeArguments_t:
 		int displayNumber
 		unsigned int regionBegin
-		unsigned int regionSize
+		int regionSize
 		char *text
 		int textSize
 		unsigned char *andMask

--- a/Documents/Manual-BrlAPI/English/BrlAPI.sgml
+++ b/Documents/Manual-BrlAPI/English/BrlAPI.sgml
@@ -1461,10 +1461,12 @@ flag weight):
 display has several. If not given, usual display is used.
 <item> A region must be given as two integers indicating the beginning and the
 number of characters of the part of the braille display which is to be updated,
-the first cell of the display being numbered 1.
+the first cell of the display being numbered 1. If the number is negative, its
+absolute value is taken into account, and the update is padded or truncated to
+fill the rest of the display.
 <item> The text to display can then be given, preceded by its size in bytes
 expressed as an integer. It will erase the corresponding region in the AND and
-OR fields. The text's length in characters must exactly match the region
+OR fields. If the region size is positive, the text's length in characters must exactly match the region
 size. For multibyte text, this is the number of wide characters. Notably,
 combining and double-width characters count for 1.
 <item> Then an AND field can be given, one byte per character: the 8-dot

--- a/Programs/brlapi.h.in
+++ b/Programs/brlapi.h.in
@@ -593,7 +593,7 @@ int BRLAPI_STDCALL brlapi__writeDots(brlapi_handle_t *handle, const unsigned cha
 typedef struct {
   int displayNumber /** Display number ::BRLAPI_DISPLAY_DEFAULT == unspecified */;
   unsigned int regionBegin /** Region of display to update, 1st character of display is 1 */;
-  unsigned int regionSize /** Number of characters held in text, andMask and orMask. */;
+  int regionSize /** Number of characters held in andMask and orMask. If negative, its absolute value is taken into account, and the output is padded or truncated to fill the rest of the display. */;
   const char *text /** Text to display, must hold as many characters as the region fields expresses. */;
   int textSize /** Size of text in bytes. If -1, strlen() is used for computing it. */;
   const unsigned char *andMask /** And attributes; applied first */;


### PR DESCRIPTION
To simplify the client brlapi_write management, the server can manage
itself padding / truncating the text being displayed.