### PR TITLE
Revert "Use fchmod (not chmod) to adjust the BrlAPI socket permissions. (dm)"

### DIFF
--- a/Drivers/Screen/AtSpi2/a2_screen.c
+++ b/Drivers/Screen/AtSpi2/a2_screen.c
@@ -1454,7 +1454,10 @@ addWatches (void) {
   };
 
   for (const WatchEntry *watch=watchTable; watch->message; watch+=1) {
-    if (!addWatch(watch->message, watch->event)) return 0;
+    if (!addWatch(watch->message, watch->event)) {
+      logMessage(LOG_ERR, "can't add watch %s %s", watch->message, watch->event);
+      return 0;
+    }
   }
 
   return 1;
@@ -1483,7 +1486,10 @@ construct_AtSpi2Screen (void) {
     goto noBus;
   }
 
-  if (!dbus_connection_add_filter(bus, AtSpi2Filter, NULL, NULL)) goto noConnection;
+  if (!dbus_connection_add_filter(bus, AtSpi2Filter, NULL, NULL)) {
+    logMessage(LOG_ERR, "can't add atspi2 filter");
+    goto noConnection;
+  }
   if (!addWatches()) goto noWatches;
 
   if (!curPath) {


### PR DESCRIPTION
This reverts commit 81cc72e023f6ca0fe6952d9b266ed937b38d28bc.

fstat on a unix socket does not actually get the socket inode status, so
that cannot be used for fixing the permissions.