### PR TITLE
configure.ac: fix LD, STRIP and RANLIB hardcoding

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -404,9 +404,9 @@ else
 fi
 AC_SUBST([LIBCXXFLAGS])
 
-AC_PATH_TOOL([LD], [ld])
-AC_PATH_TOOL([STRIP], [strip])
-AC_PATH_TOOL([RANLIB], [ranlib])
+AC_CHECK_TOOL([LD], [ld])
+AC_CHECK_TOOL([STRIP], [strip])
+AC_CHECK_TOOL([RANLIB], [ranlib])
 
 AC_PROG_AWK
 AC_PROG_LN_S


### PR DESCRIPTION
When building the project with LLVM/Clang it is desirable to
be able to use the LLD linker as well as llvm-strip/ranlib
so replace the path-based hardcoded tool name search with a
more flexible AC_CHECK_TOOL search.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>