### PR TITLE
brlapi_client: Fix using the number of sessions

### DIFF
--- a/Programs/brlapi_client.c
+++ b/Programs/brlapi_client.c
@@ -1736,12 +1736,12 @@ int BRLAPI_STDCALL brlapi__enterTtyModeWithPath(brlapi_handle_t *handle, const i
       } else {
 	char **sessions;
 	/* Not even logind knows :/ we are probably logged in from gdm */
-	ret = sd_uid_get_sessions(getuid(), 0, &sessions);
+	int nsessions = sd_uid_get_sessions(getuid(), 0, &sessions);
 
-	if (ret > 0) {
+	if (nsessions > 0) {
 	  int i, chosen = -1;
 
-	  for (i = 0; i < ret; i++) {
+	  for (i = 0; i < nsessions; i++) {
 	    char *type;
 
 	    ret = sd_session_get_type(sessions[i], &type);
@@ -1763,7 +1763,7 @@ int BRLAPI_STDCALL brlapi__enterTtyModeWithPath(brlapi_handle_t *handle, const i
 
 	  if (chosen >= 0) sd_session_get_vt(sessions[i], &vtnr);
 
-	  for (i = 0; i < ret; i++) free(sessions[i]);
+	  for (i = 0; i < nsessions; i++) free(sessions[i]);
 	  free(sessions);
 	}
       }


### PR DESCRIPTION
We were assuming that ret still contains the number of sessions, so we were
not supposed to overwrite it. We rather use an explicit separate variable
then.