### PR TITLE
Handle Debian's default posix_prefix sysconfig layout

### DIFF
--- a/Tools/pythoncmd
+++ b/Tools/pythoncmd
@@ -50,6 +50,9 @@ try:
     scheme = sysconfig.get_default_scheme()
   else:
     scheme = sysconfig._get_default_scheme()
+  if scheme == 'posix_local':
+    # Debian's default scheme installs to /usr/local/ but we want to find headers in /usr/
+    scheme = 'posix_prefix'
 
   def getIncludeDirectory():
     return sysconfig.get_path("include", scheme)

--- a/Tools/pythoncmd
+++ b/Tools/pythoncmd
@@ -46,15 +46,19 @@ except IndexError:
 try:
   import sysconfig
 # putProgramMessage("sysconfig")
+  if hasattr(sysconfig, 'get_default_scheme'):
+    scheme = sysconfig.get_default_scheme()
+  else:
+    scheme = sysconfig._get_default_scheme()
 
   def getIncludeDirectory():
-    return sysconfig.get_path("include")
+    return sysconfig.get_path("include", scheme)
 
   def getLibraryDirectory():
-    return sysconfig.get_path("stdlib")
+    return sysconfig.get_path("stdlib", scheme)
 
   def getPackageDirectory():
-    return sysconfig.get_path("platlib")
+    return sysconfig.get_path("platlib", scheme)
 
   def getConfigurationVariable(name):
     return sysconfig.get_config_var(name)


### PR DESCRIPTION
Fixes Debian's bug: https://bugs.debian.org/1007927

Debian adds a custom sysconfig scheme to system python installs, "posix_local". This is the default scheme, and it redirects local users' Python module installs to /usr/local even though Python is installed with a /usr prefix. Both are on Debian's python's sys.path module search path.

Previously this custom sysconfig scheme was specified in distutils.sysconfig, but not sysconfig itself. As distutils is being deprecated, the custom scheme is now specified in sysconfig, since Debian's Python 3.10 (3.10.2-4).

As far as I can see, pythoncmd is only used in detecting the installed system python, not determining where the built module will be installed, so this patch is sufficient. To control where the module is installed, the approach would be to pass the selected prefix to sysconfig, when querying the install path.