### PR TITLE
AtSpi2: convert standard control characters into special keys

### DIFF
--- a/Drivers/Screen/AtSpi2/a2_screen.c
+++ b/Drivers/Screen/AtSpi2/a2_screen.c
@@ -1691,6 +1691,13 @@ insertKey_AtSpi2Screen (ScreenKey key) {
   long keysym;
   int modMeta=0, modControl=0;
 
+  switch (key) {
+    case '\n':   key = SCR_KEY_ENTER;     break;
+    case '\t':   key = SCR_KEY_TAB;       break;
+    case '\b':   key = SCR_KEY_BACKSPACE; break;
+    case '\033': key = SCR_KEY_ESCAPE;    break;
+  }
+
   setScreenKeyModifiers(&key, SCR_KEY_CONTROL);
 
   if (isSpecialKey(key)) {


### PR DESCRIPTION
Rather than letting setScreenKeyModifiers turn them into control-[A-Z],
because most X applications will consider those as shortcuts instead of
interpreting them as control characters.