### PR TITLE
Emacs binding changes

### DIFF
--- a/Bindings/Emacs/apitest
+++ b/Bindings/Emacs/apitest
@@ -17,5 +17,5 @@
 ###############################################################################
 
 . "${0%/*}/../../apitest.sh"
-exec emacs --batch --no-site-file -L . -l apitest.el
+exec emacs --batch --no-site-file -L . -l apitest.el "${@}"
 exit "${?}"

--- a/Bindings/Emacs/apitest.el
+++ b/Bindings/Emacs/apitest.el
@@ -1,8 +1,10 @@
 (load "brlapi")
 
-(defvar brl (brlapi-open-connection))
+(defvar brl (apply #'brlapi-open-connection command-line-args-left))
 
 (message "Driver Name: %s" (brlapi-get-driver-name brl))
-(message "Display Size: %S" (brlapi-get-display-size brl))
+(message "Model Identifier: %s" (brlapi-get-model-identifier brl))
+(let ((size (brlapi-get-display-size brl)))
+  (message "Display Size: %dx%d" (car size) (cdr size)))
 
 (brlapi-close-connection brl)

--- a/Bindings/Emacs/bindings.c
+++ b/Bindings/Emacs/bindings.c
@@ -33,10 +33,10 @@ error(emacs_env *env) {
   const char *const str = brlapi_strerror(&brlapi_error);
   emacs_value error_symbol = env->intern(env, error_name);
   emacs_value data[] = {
+    env->make_string(env, str, strlen(str)),
     env->make_integer(env, brlapi_errno),
     env->make_integer(env, brlapi_libcerrno),
-    env->make_integer(env, brlapi_gaierrno),
-    env->make_string(env, str, strlen(str))
+    env->make_integer(env, brlapi_gaierrno)
   };
 
   env->non_local_exit_signal(env,


### PR DESCRIPTION
- Pass Emacs apitest command line arguments to brlapi-open-connection. (ml)
- Change brlapi-error data items such that the explanatory string comes first. (ml)
