### PR TITLE
Python: tell cython to embed the functions signatures

### DIFF
--- a/Bindings/Python/Makefile.in
+++ b/Bindings/Python/Makefile.in
@@ -56,7 +56,7 @@ $(INSTALLED_FILES):
 	touch $(INSTALLED_FILES)
 
 brlapi.auto.c: $(SRC_DIR)/brlapi.pyx $(SRC_DIR)/c_brlapi.pxd constants.auto.pyx
-	"$(CYTHON)" -$(PYTHON_VERSION) -I. -o $@ $(SRC_DIR)/brlapi.pyx
+	"$(CYTHON)" -$(PYTHON_VERSION) -I. -X embedsignature=True -o $@ $(SRC_DIR)/brlapi.pyx
 
 constants.auto.pyx: $(CONSTANTS_DEPENDENCIES)
 	$(AWK) $(CONSTANTS_ARGUMENTS) >$@


### PR DESCRIPTION
Otherwise the pydoc documentation does not actually show the parameters
of the function.