### PR TITLE
Fix QBrailleXL unrecognizable in the second connection

### DIFF
--- a/Drivers/Braille/HIMS/braille.c
+++ b/Drivers/Braille/HIMS/braille.c
@@ -632,7 +632,7 @@ brl_construct (BrailleDisplay *brl, char **parameters, const char *device) {
 
     if (connectResource(brl, device)) {
       if (!(brl->data->protocol = gioGetApplicationData(brl->gioEndpoint))) {
-        char *name = gioGetResourceName(brl->gioEndpoint);
+        char *name = strdup(gioGetResourceName(brl->gioEndpoint));
         brl->data->protocol = &brailleSenseProtocol;
 
         if (name) {


### PR DESCRIPTION
The "name" pointer will be free in line#655. This will make device->name return a memory position which already be free. This change make the free() always free the duplicated name instead of the name in memory.