### PR TITLE
Stack overflow when connect with bm driver with 64-bits CPU architecture

### DIFF
--- a/Programs/ktb_compile.c
+++ b/Programs/ktb_compile.c
@@ -1517,7 +1517,7 @@ addIncompleteBindings (KeyContext *ctx) {
   if (!count) return 1;
 
   size_t size = count * sizeof(*ctx->keyBindings.table);
-  KeyBinding bindings[size];
+  KeyBinding* bindings = (KeyBinding *) malloc(size * sizeof(KeyBinding)) ;
   memcpy(bindings, ctx->keyBindings.table, size);
 
   const KeyBinding *binding = bindings;
@@ -1525,11 +1525,14 @@ addIncompleteBindings (KeyContext *ctx) {
 
   while (binding < end) {
     const KeyCombination *combination = &binding->keyCombination;
-    if (!addIncompleteBinding(ctx, combination->modifierKeys, combination->modifierCount)) return 0;
-    if (!addIncompleteSubbindings(ctx, combination->modifierKeys, combination->modifierCount)) return 0;
+    if (!addIncompleteBinding(ctx, combination->modifierKeys, combination->modifierCount)
+      || !addIncompleteSubbindings(ctx, combination->modifierKeys, combination->modifierCount)) {
+      free(bindings);
+      return 0;
+    }
     binding += 1;
   }
-
+  free(bindings);
   return 1;
 }
 


### PR DESCRIPTION
There is a crash happens in create KeyBinding array: "Cause: stack pointer is in a non-existent map; likely due to stack overflow." while trying to connect with Orbit reader 20 in 64 bit CPU architecture which the size variable in this case is more than 15,000. It seems static creation is not enough for this case so we propose malloc solution and the stack overflow not exists anymore.