### PR TITLE
Revert "Add the pushProgramTerminationCommand shell function. (dm)"

### DIFF
--- a/brltty-prologue.sh
+++ b/brltty-prologue.sh
@@ -94,41 +94,6 @@ logDetail() {
    logMessage detail "${@}"
 }
 
-programTerminationCommandCount=0
-
-runProgramTerminationCommands() {
-   set +e
-
-   while [ "${programTerminationCommandCount}" -gt 0 ]
-   do
-      set -- $(getVariable "programTerminationCommand${programTerminationCommandCount}")
-      let "programTerminationCommandCount -= 1"
-
-      local process="${1}"
-      local directory="${2}"
-      shift 2
-
-      [ "${process}" = "${$}" ] && {
-         cd "${directory}"
-         "${@}"
-      }
-   done
-}
-
-pushProgramTerminationCommand() {
-   [ "${programTerminationCommandCount}" -gt 0 ] || trap runProgramTerminationCommands exit
-   setVariable "programTerminationCommand$((programTerminationCommandCount += 1))" "${$} $(pwd) ${*}"
-}
-
-needTemporaryDirectory() {
-   [ -n "${temporaryDirectory}" ] || {
-      umask 022
-      [ -n "${TMPDIR}" -a -d "${TMPDIR}" -a -r "${TMPDIR}" -a -w "${TMPDIR}" -a -x "${TMPDIR}" ] || export TMPDIR="/tmp"
-      temporaryDirectory="$(mktemp -d "${TMPDIR}/${programName}.$(date +"%Y%m%d-%H%M%S").XXXXXX")" && cd "${temporaryDirectory}" || exit "${?}"
-      pushProgramTerminationCommand rm -f -r -- "${temporaryDirectory}"
-   }
-}
-
 resolveDirectory() {
    local path="${1}"
    local variable="${2}"
@@ -510,6 +475,19 @@ verifyOutputDirectory() {
    else
       mkdir -p "${path}"
    fi
+}
+
+needTemporaryDirectory() {
+   cleanup() {
+      set +e
+      cd /
+      [ -z "${temporaryDirectory}" ] || rm -f -r -- "${temporaryDirectory}"
+   }
+   trap "cleanup" 0
+
+   umask 022
+   [ -n "${TMPDIR}" -a -d "${TMPDIR}" -a -r "${TMPDIR}" -a -w "${TMPDIR}" -a -x "${TMPDIR}" ] || export TMPDIR="/tmp"
+   temporaryDirectory="$(mktemp -d "${TMPDIR}/${programName}.XXXXXX")" && cd "${temporaryDirectory}" || exit "${?}"
 }
 
 programParameterCount=0


### PR DESCRIPTION
Fixes infinite loop during configure:
```
config.status: executing build-configure commands
configure: WARNING: libudev support not available
configure: WARNING: Human Interface Device I/O support not available on this platform
./mk4build: 104: let: not found
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
./mk4build: 104: let: not found
./mk4build: 111: cd: can't cd to /tmp/mk4build.20221015-092924.ZL6KlF
```

This reverts commit df1e070d30f583381b48fddd829bdde8efcdd16a.

Broken commit identified via git bisect.