### PR TITLE
terminal emulator scrolling optimization

### DIFF
--- a/Drivers/Screen/TerminalEmulator/em_screen.c
+++ b/Drivers/Screen/TerminalEmulator/em_screen.c
@@ -485,11 +485,10 @@ readCharacters_TerminalEmulatorScreen (const ScreenBox *box, ScreenCharacter *bu
 
   if (validateScreenBox(box, segment->screenWidth, segment->screenHeight)) {
     ScreenCharacter *target = buffer;
-    const ScreenSegmentCharacter *source = getScreenStart(segment);
-    source += (box->top * segment->screenWidth) + box->left;
-    unsigned int sourceRowIncrement = segment->screenWidth - box->width;
 
     for (unsigned int row=0; row<box->height; row+=1) {
+      const ScreenSegmentCharacter *source =
+          getScreenCharacter(segment, box->top + row, box->left, NULL);
       for (unsigned int column=0; column<box->width; column+=1) {
         target->text = source->text;
 
@@ -510,8 +509,6 @@ readCharacters_TerminalEmulatorScreen (const ScreenBox *box, ScreenCharacter *bu
         source += 1;
         target += 1;
       }
-
-      source += sourceRowIncrement;
     }
 
     return 1;

--- a/Headers/scr_terminal.h
+++ b/Headers/scr_terminal.h
@@ -57,8 +57,6 @@ typedef struct {
   uint32_t segmentSize;
 
   uint32_t characterSize;
-  uint32_t charactersOffset;
-
   uint32_t screenHeight;
   uint32_t screenWidth;
 
@@ -68,6 +66,8 @@ typedef struct {
   uint32_t screenNumber;
   uint32_t commonFlags;
   uint32_t privateFlags;
+
+  uint32_t rowOffsets[0];
 } ScreenSegmentHeader;
 
 extern int getScreenSegment (int *identifier, key_t key);
@@ -77,10 +77,8 @@ extern int detachScreenSegment (ScreenSegmentHeader *segment);
 extern ScreenSegmentHeader *getScreenSegmentForKey (key_t key);
 extern ScreenSegmentHeader *getScreenSegmentForPath (const char *path);
 
-extern ScreenSegmentCharacter *getScreenStart (ScreenSegmentHeader *segment);
 extern ScreenSegmentCharacter *getScreenRow (ScreenSegmentHeader *segment, unsigned int row, ScreenSegmentCharacter **end);
 extern ScreenSegmentCharacter *getScreenCharacter (ScreenSegmentHeader *segment, unsigned int row, unsigned int column, ScreenSegmentCharacter **end);
-extern const ScreenSegmentCharacter *getScreenEnd (ScreenSegmentHeader *segment);
 
 #ifdef __cplusplus
 }

--- a/Programs/pty_screen.c
+++ b/Programs/pty_screen.c
@@ -566,7 +566,10 @@ ptyClearToEndOfDisplay (void) {
   clrtobot();
 
   ScreenSegmentCharacter *from = setCurrentCharacter(NULL);
-  const ScreenSegmentCharacter *to = getScreenEnd(segmentHeader);
+
+  const ScreenSegmentCharacter *to;
+  getScreenRow(segmentHeader, segmentHeader->screenHeight-1, &to);
+
   propagateScreenCharacter(from, to);
 }
 

--- a/Programs/scr_terminal.c
+++ b/Programs/scr_terminal.c
@@ -104,23 +104,15 @@ getScreenSegmentForPath (const char *path) {
 }
 
 ScreenSegmentCharacter *
-getScreenStart (ScreenSegmentHeader *segment) {
-  void *address = segment;
-  address += segment->charactersOffset;
-  return address;
-}
-
-ScreenSegmentCharacter *
 getScreenRow (ScreenSegmentHeader *segment, unsigned int row, ScreenSegmentCharacter **end) {
-  void *character = getScreenStart(segment);
-  unsigned int width = segment->screenWidth * segment->characterSize;
-  character += row * width;
+  void *address = segment;
+  address += segment->rowOffsets[row];
 
   if (end) {
-    *end = character + width;
+    *end = address + segment->screenWidth * segment->characterSize;
   }
 
-  return character;
+  return address;
 }
 
 ScreenSegmentCharacter *
@@ -128,9 +120,4 @@ getScreenCharacter (ScreenSegmentHeader *segment, unsigned int row, unsigned int
   void *address = getScreenRow(segment, row, end);
   address += column * segment->characterSize;
   return address;
-}
-
-const ScreenSegmentCharacter *
-getScreenEnd (ScreenSegmentHeader *segment) {
-  return getScreenRow(segment, segment->screenHeight, NULL);
 }


### PR DESCRIPTION
- terminal emulator: make rows directly indexable
- terminal emulator: shift row indices rather than whole memory when scrolling
