### PR TITLE
Fix crash on GetModelIdentifier while driver unconstructed

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -832,7 +832,7 @@ static int handleGetDriverName(Connection *c, brlapi_packetType_t type, brlapi_p
 
 static int handleGetModelIdentifier(Connection *c, brlapi_packetType_t type, brlapi_packet_t *packet, size_t size)
 {
-  return handleGetDriver(c, type, size, disp->keyBindings);
+  return handleGetDriver(c, type, size, disp ? disp->keyBinding : "");
 }
 
 static int handleGetDisplaySize(Connection *c, brlapi_packetType_t type, brlapi_packet_t *packet, size_t size)


### PR DESCRIPTION
If the braille driver is not constructed, disp is NULL, and thus a BrlAPI GetModelIdentifier request would crash. Return an empty string instead in that case.