### PR TITLE
brlapi: Fix erroneous free on bogus parameter unregistration

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -2476,7 +2476,7 @@ static int handleParamRequest(Connection *c, brlapi_packetType_t type, brlapi_pa
 	  && (s->flags & BRLAPI_PARAMF_GLOBAL) == (flags & BRLAPI_PARAMF_GLOBAL))
 	break;
     }
-    if (s) {
+    if (s != &c->subscriptions) {
       if (flags & BRLAPI_PARAMF_GLOBAL)
         paramState[param].global_subscriptions--;
       else


### PR DESCRIPTION
The check for early exit from the for loop was wrong.