### PR TITLE
AtSpi2: Fix crash on routing request

### DIFF
--- a/Drivers/Screen/AtSpi2/a2_screen.c
+++ b/Drivers/Screen/AtSpi2/a2_screen.c
@@ -1571,8 +1571,10 @@ destruct_AtSpi2Screen (void) {
   brlttyDisableInterrupt();
 #ifdef HAVE_PKG_X11
   if (dpy) {
-    unregisterReportListener(coreSelUpdatedListener);
-    coreSelUpdatedListener = NULL;
+    if (coreSelUpdatedListener) {
+      unregisterReportListener(coreSelUpdatedListener);
+      coreSelUpdatedListener = NULL;
+    }
     if (a2XWatch) {
       asyncCancelRequest(a2XWatch);
       a2XWatch = NULL;


### PR DESCRIPTION
We would otherwise get, here with ubsan:

```
brltty: report listener already registered: 5: a2CoreSelUpdated UndefinedBehaviorSanitizer:DEADLYSIGNAL
==2087615==ERROR: UndefinedBehaviorSanitizer: SEGV on unknown address 0x000000000000 (pc 0x56356b124850 bp 0x000000000000 sp 0x7fcc4d9fdbd8 T2087615) ==2087615==The signal is caused by a READ memory access. ==2087615==Hint: address points to the zero page.
    #0 0x56356b124850 in unregisterReportListener /home/samy/brl/mielke-svn/brltty/Programs/./report.c:208:22
    #1 0x7fcc5233f0ab in destruct_AtSpi2Screen /home/samy/brl/mielke-svn/brltty/Drivers/Screen/AtSpi2/./a2_screen.c:1574:5
    #2 0x56356b15304d in destructRoutingScreen /home/samy/brl/mielke-svn/brltty/Programs/./scr.c:255:3
    #3 0x56356b1542e9 in startRoutingProcess /home/samy/brl/mielke-svn/brltty/Programs/./routing.c:498:9
    #4 0x56356b1542e9 in runRoutingThread /home/samy/brl/mielke-svn/brltty/Programs/./routing.c:543:17
    #5 0x56356b11f574 in runThreadFunction /home/samy/brl/mielke-svn/brltty/Programs/./thread.c:151:33
    #6 0x56356b11f857 in runThread /home/samy/brl/mielke-svn/brltty/Programs/./thread.c:46:18
    #7 0x7fcc4f9c8fd3 in start_thread nptl/./nptl/pthread_create.c:442:8
    #8 0x7fcc4fa4966b in clone3 misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```