### PR TITLE
proc/*/stat parsing bug

### DIFF
--- a/Programs/brlapi_client.c
+++ b/Programs/brlapi_client.c
@@ -1659,41 +1659,46 @@ static int getControllingTty(void)
 #endif /* WINDOWS */
 
 #ifdef linux
-  {
-    int fd;
-    if ((fd = open("/proc/self/stat", O_RDONLY, 0)) >= 0) {
-      char buf[256];
-      size_t read_bytes = read(fd, buf, sizeof(buf) - 1);
-      close(fd);
-      /* Append null at the end of buffer to ensure that read doesn't
-       * overflows.*/
-      buf[255] = '\0';
-
-      /* The line format is "$pid ($comm) $state ...
-       * where comm may contain space and `)` as part of its name, ex:
-       * 12345 (someproc) S 123 456) R ...
-       * So to process valid identified after comm, we should skip comm by
-       * getting the 1st ) from end.
-       */
-      char *ptr = buf + read_bytes - 1;
-      while (buf < ptr && *ptr != ')') {
-        ptr -= 1;
-      }
-      if (*ptr != ')') {
-        return -1;
-      }
-      /* Point to space after ($comm). */
-      ptr += 1;
-
-      int vt;
-      int ok = sscanf(ptr, " %*c %*d %*d %*d %d", &tty) == 1;
-
-      if (ok && (major(tty) == TTY_MAJOR)) {
-        vt = minor(tty);
-        if ((vt >= 1) && (vt <= MAXIMUM_VIRTUAL_CONSOLE)) return vt;
-      }
+  do {
+    int fd = open("/proc/self/stat", O_RDONLY, 0);
+    if (fd < 0) {
+      break;
     }
-  }
+
+    char buf[256];
+    ssize_t read_bytes = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (read_bytes < 0) {
+      break;
+    }
+    /* Append null at the end of buffer to ensure that read doesn't
+     * overflows.*/
+    buf[read_bytes] = '\0';
+
+    /* The line format is "$pid ($comm) $state ...
+     * where comm may contain space and `)` as part of its name, ex:
+     * 12345 (some proc (foo) S 123 456) R ...
+     * So to process valid identified after comm, we should skip comm by
+     * getting the 1st `)` from end.
+     */
+    char *ptr = buf + read_bytes - 1;
+    while (ptr > buf && *ptr != ')') {
+      ptr -= 1;
+    }
+    if (*ptr != ')') {
+      break;
+    }
+    /* Point to space after ($comm). */
+    ptr += 1;
+
+    int vt;
+    int ok = sscanf(ptr, " %*c %*d %*d %*d %d", &tty) == 1;
+
+    if (ok && (major(tty) == TTY_MAJOR)) {
+      vt = minor(tty);
+      if ((vt >= 1) && (vt <= MAXIMUM_VIRTUAL_CONSOLE)) return vt;
+    }
+  } while (0);
 #endif /* linux */
 
   return -1;

--- a/Programs/brlapi_client.c
+++ b/Programs/brlapi_client.c
@@ -1671,13 +1671,13 @@ static int getControllingTty(void)
     if (read_bytes < 0) {
       break;
     }
-    /* Append null at the end of buffer to ensure that read doesn't
+    /* Append null at the end of buffer to ensure that sscanf doesn't
      * overflows.*/
     buf[read_bytes] = '\0';
 
     /* The line format is "$pid ($comm) $state ...
      * where comm may contain space and `)` as part of its name, ex:
-     * 12345 (some proc (foo) S 123 456) R ...
+     * 12345 (some proc (foo)) R ...
      * So to process valid identified after comm, we should skip comm by
      * getting the 1st `)` from end.
      */


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1024811

($comm) can contain space or even ) in its name. So in order to parse it correctly, we should treat comm to be between 1st '(' and last ')'. 

Since this code doesn't really consume $comm, we can just skip it by getting the first ')' from end, and start processing after that. 