### PR TITLE
brlapi: Simplify keyrange management

### DIFF
--- a/Programs/brlapi_keyranges.c
+++ b/Programs/brlapi_keyranges.c
@@ -145,7 +145,6 @@ int removeKeyrange(KeyrangeElem x0, KeyrangeElem y0, KeyrangeList **l)
   uint32_t minVal   = MIN(KeyrangeVal(x0), KeyrangeVal(y0));
   uint32_t maxVal   = MAX(KeyrangeVal(x0), KeyrangeVal(y0));
   KeyrangeList *c, **p, *tmp;
-  int i;
 
   if ((l==NULL) || (*l==NULL)) return 0;
 
@@ -190,45 +189,21 @@ int removeKeyrange(KeyrangeElem x0, KeyrangeElem y0, KeyrangeList **l)
       c->maxVal = maxVal;
     }
 
-    /* Now values are the same, tinker with flags */
-    for (i=0; i<32; i++) {
-      uint32_t mask = 1U<<i;
+    /* Now values are contained in suppression, intersect against flags */
 
-      if ((!(c->maxFlags & mask) &&  (minFlags & mask)) ||
-          ( (c->minFlags & mask) && !(maxFlags & mask)))
-	/* don't intersect on this flag */
-	continue;
-
-      if (!(c->minFlags & mask) &&  (minFlags & mask)) {
-        /* && (c->maxFlags & mask) */
-	/* part without flag i should be kept intact, save it */
-        p = createKeyrange(p, c->minFlags, c->minVal, c->maxFlags & ~mask, c->maxVal, c);
-        if (p == NULL) return -1;
-	/* now handling part with flag i */
-        c->minFlags |= mask;
-      }
-
-      if ( (c->maxFlags & mask) && !(maxFlags & mask)) {
-        /* && !(c->minFlags & mask) */
-	/* part with flag i should be kept intact, save it */
-        p = createKeyrange(p, c->minFlags | mask, c->minVal, c->maxFlags, c->maxVal, c);
-        if (p == NULL) return -1;
-	/* now handling part without flag i */
-        c->maxFlags &= ~mask;
-      }
-
-      if (!(c->maxFlags | ~minFlags) || !(~c->minFlags | maxFlags))
-        /* don't intersect any more*/
-	break;
-    }
-    if (i<32) {
-      /* don't intersect any more, keep it */
-      break;
-    } else {
-      /* remaining intersection, drop it */
+    if (~minFlags & maxFlags) {
+      /* At least some flag must now be neither cleared nor set, drop range */
       tmp = c; c = c->next;
       freeKeyrange(p,tmp);
+      continue;
     }
+
+    /* Clamp flags on the value interval */
+    c->minFlags |= ~maxFlags;
+    c->maxFlags &= ~minFlags;
+
+    p = &c->next;
+    c = *p;
   }
 
   return 0;


### PR DESCRIPTION
There is no need to separate each bit processing: either we remove the full range because ~minFlags & maxFlags != 0, or we just clamp the permitted flags.

This avoids an exploding set of ranges when repeatedly removing intervals, as found by fuzzing.