### PR TITLE
brlapi: Do not free connection window when re-entering tty fails

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -917,7 +917,6 @@ static int handleEnterTtyMode(Connection *c, brlapi_packetType_t type, brlapi_pa
        * doesn't exist yet. This is forbidden. */
       unlockMutex(&apiConnectionsMutex);
       WERR(c->fd, BRLAPI_ERROR_INVALID_PARAMETER, "already having another tty");
-      freeBrailleWindow(&c->brailleWindow);
       return 0;
     }
     /* ok, allocate path */


### PR DESCRIPTION
In case a connection had already entered a tty, we should not free the windows, otherwise the core will try to display it, and crash.

Found by fuzzing.