### PR TITLE
Modified keymaps for Activator to reflect latest firmware modifications.

### DIFF
--- a/Drivers/Braille/HandyTech/braille.c
+++ b/Drivers/Braille/HandyTech/braille.c
@@ -88,6 +88,16 @@ BEGIN_KEY_NAME_TABLE(rockers)
   KEY_NAME_ENTRY(HT_KEY_Down, "RightRockerBottom"),
 END_KEY_NAME_TABLE
 
+BEGIN_KEY_NAME_TABLE(navigation)
+  KEY_NAME_ENTRY(HT_KEY_Escape, "Display1"),
+  KEY_NAME_ENTRY(HT_KEY_LeftCenter, "Display2"),
+  KEY_NAME_ENTRY(HT_KEY_Return, "Display3"),
+
+  KEY_NAME_ENTRY(HT_KEY_Up, "Display4"),
+  KEY_NAME_ENTRY(HT_KEY_RightCenter, "Display5"),
+  KEY_NAME_ENTRY(HT_KEY_Down, "Display6"),
+END_KEY_NAME_TABLE
+
 BEGIN_KEY_NAME_TABLE(joystick)
   KEY_NAME_ENTRY(HT_KEY_JoystickLeft, "Left"),
   KEY_NAME_ENTRY(HT_KEY_JoystickRight, "Right"),
@@ -255,7 +265,7 @@ END_KEY_NAME_TABLES
 BEGIN_KEY_NAME_TABLES(ac4)
   KEY_NAME_TABLE(routing),
   KEY_NAME_TABLE(dots),
-  KEY_NAME_TABLE(rockers),
+  KEY_NAME_TABLE(navigation),
   KEY_NAME_TABLE(brailleStar),
   KEY_NAME_TABLE(joystick),
 END_KEY_NAME_TABLES

--- a/Drivers/Braille/HandyTech/brldefs-ht.h
+++ b/Drivers/Braille/HandyTech/brldefs-ht.h
@@ -211,6 +211,10 @@ typedef enum {
   HT_KEY_JoystickDown       = 0X77,
   HT_KEY_JoystickAction     = 0X78,
 
+  /* Activator keys */
+  HT_KEY_LeftCenter         = 0X7A,
+  HT_KEY_RightCenter        = 0X7B,
+
   /* ranges and flags */
   HT_KEY_ROUTING = 0X20,
   HT_KEY_STATUS = 0X70,

--- a/Tables/Input/ht/ac4.ktb
+++ b/Tables/Input/ht/ac4.ktb
@@ -21,4 +21,34 @@ title HandyTech Activator
 bind B1+B4+SpaceLeft TOUCH_NAV
 
 include joystick.kti
-include bs.kti
+bind RoutingKey ROUTE
+bind RoutingKey+!RoutingKey CLIP_COPY
+
+bind SpaceLeft+RoutingKey PRINDENT
+bind SpaceRight+RoutingKey NXINDENT
+
+bind SpaceLeft FWINLT
+bind SpaceRight FWINRT
+bind SpaceLeft+SpaceRight PASTE
+
+bind B1+SpaceLeft LNBEG
+bind B1+SpaceRight LNEND
+bind B2+SpaceLeft TOP
+bind B2+SpaceRight BOT
+bind B3+SpaceLeft HWINLT
+bind B3+SpaceRight HWINRT
+bind B6+SpaceLeft CHRLT
+bind B6+SpaceRight CHRRT
+bind B2+B3+SpaceLeft MUTE
+bind B2+B3+SpaceRight SAY_LINE
+
+include dots.kti
+
+assign brailleOn B1+B8+SpaceRight
+assign brailleOff B1+B8+SpaceLeft
+assign space SpaceLeft
+assign enter SpaceRight
+include input.kti
+
+include ../bm/display6.kti
+include ../bm/routing6.kti


### PR DESCRIPTION
For Activator, the rockers have been replaced by navigation keys, some of which retain the keycodes also emitted by the rockers. The functionality should be identical to the six keys found on Basic Braille devices, so I have assigned them to Display1 up to Display6 just as Basic Braille does.