### PR TITLE
Add gettext header to ru.po

### DIFF
--- a/Messages/ru.po
+++ b/Messages/ru.po
@@ -1,3 +1,34 @@
+# BRLTTY - A background process providing access to the console screen (when in
+#          text mode) for a blind person using a refreshable braille display.
+#
+# Copyright (C) 1995-2022 by The BRLTTY Developers.
+#
+# BRLTTY comes with ABSOLUTELY NO WARRANTY.
+#
+# This is free software, placed under the terms of the
+# GNU Lesser General Public License, as published by the Free Software
+# Foundation; either version 2.1 of the License, or (at your option) any
+# later version. Please see the file LICENSE-LGPL for details.
+#
+# Web Page: http://brltty.app/
+#
+# This software is maintained by Dave Mielke <dave@mielke.cc>.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: brltty 4.5\n"
+"Report-Msgid-Bugs-To: BRLTTY@brltty.app\n"
+"POT-Creation-Date: 2021-01-27 11:47-0500\n"
+"PO-Revision-Date: 2021-02-07 08:18-0500\n"
+"Last-Translator: Маргарита Мельникова <margaretmelnikova@gmail.com>\n"
+"Language-Team: Friends of BRLTTY <BRLTTY@brlttY.app>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
 #: Programs/brltty.c:167
 #, c-format
 msgid "\"%s\" started as \"%s\"\n"


### PR DESCRIPTION
Building with gettext-0.22 fails for lack of this header:

```
/usr/bin/msgfmt: input file doesn't contain a header entry with a charset specification
```

The information in this header was reconstructed from git history.  This is needed to fix the build of brltty in Fedora rawhide (39) and ELN.
