### PR TITLE
Add winerror.h to prologue for Windows

### DIFF
--- a/Headers/prologue.h
+++ b/Headers/prologue.h
@@ -147,6 +147,7 @@ static inline void __sync_synchronize (void) {}
 #endif /* __MINGW32__ */
 
 #include <windows.h>
+#include <winerror.h>
 #endif /* WINDOWS */
 
 #ifdef __MINGW32__


### PR DESCRIPTION
It looks like when winerror.h is missing from prologue.h, BRLTTY can't be build with newer versions of the Windows SDK. This should resolve that.