### PR TITLE
Add support for Python 3.11

### DIFF
--- a/Bindings/Python/Makefile.in
+++ b/Bindings/Python/Makefile.in
@@ -50,7 +50,6 @@ $(PYTHON_API): brlapi.auto.c $(API_HDRS) | $(INSTALLED_FILES) brlapi
 	set -- $(V_setup) build --build-temp .; \
 	[ "@host_os@" != "mingw32" ] || set -- "$${@}" --compiler mingw32; \
 	"$(PYTHON)" ./setup.py "$${@}"
-	[ "@host_os@" != "mingw32" ] || "$(PYTHON)" ./setup.py $(V_setup) bdist_wininst --skip-build
 
 $(INSTALLED_FILES):
 	touch $(INSTALLED_FILES)
@@ -69,6 +68,7 @@ install: all
 	[ -z "$(PYTHON_DESTDIR)" ] || set -- "$${@}" --root "$(PYTHON_DESTDIR)"; \
 	[ -z "$(PYTHON_PREFIX)" ] || set -- "$${@}" --prefix "$(PYTHON_PREFIX)"; \
 	"$(PYTHON)" ./setup.py "$${@}"
+	[ "@host_os@" != "mingw32" ] || "$(PYTHON)" ./setup.py $(V_setup) bdist_wheel --skip-build                    
 	-rm -f -r -- Brlapi.egg-info
 
 uninstall:

--- a/Windows/mkwin
+++ b/Windows/mkwin
@@ -294,8 +294,7 @@ Here are some notes on how to get started:
   environment, you need to also install and run NVDA.
 - Either use the BRLTTY configurator (brlttycnf.exe) or manually uncomment the
   appropriate lines in etc/brltty.conf.
-- For Python support (e.g. for NVDA), run Brlapi-${BRLAPI_RELEASE}.win32.exe
-  (which will install the .pyd and .egg-info files).
+- For Python support (e.g. for NVDA), install Brlapi-${BRLAPI_RELEASE}-<PythonVersion>-win32.whl using pip.
 - For sighted users, use the xw braille driver to get a virtual braille box.
 "
 
@@ -318,7 +317,7 @@ Technical notes on this build:
   * only use local sockets (:0+127.0.0.1:0 changed to :0)
 - *${usbPattern}* files come from ${usbName} ${usbVersion}, which can be found at:
   ${usbDownload}
-- Python bindings are provided by: Brlapi-${BRLAPI_RELEASE}.win32.exe
+- Python bindings are provided by: Brlapi-${BRLAPI_RELEASE}-<PythonVersion>-win32.whl
 - C bindings are provided in: include/, and lib/
   A .lib file is provided for linking in (for example) Visual C. Then you can
   just ship bin/brlapi${BRLAPI_RELEASE%.*}.dll alongside your .exe application.
@@ -331,7 +330,7 @@ installFile "Drivers/BrlAPI/WindowEyes/webrloem109.dll" "WindowEyes/"
 installFiles "Debug/" config.h config.mk config.log
 installFiles "Debug/" Programs/*.exe Programs/*.dll
 
-set -- Bindings/Python/dist/Brlapi-${BRLAPI_RELEASE}.*.exe
+set -- Bindings/Python/dist/Brlapi-${BRLAPI_RELEASE}-*.whl
 if [ "${#}" -gt 0 ]
 then
    for file

--- a/Windows/winsetup
+++ b/Windows/winsetup
@@ -249,7 +249,7 @@ installLibUSB1() {
    installWindowsArchive winusb.zip "${windowsDirectory}/WinUSB"
 }
 
-installCython() {
+installPythonDeps() {
    local python
 
    if findCommand python python py
@@ -262,9 +262,13 @@ installCython() {
          "${dryRun}" || executeCommand pip -q install cython
       }
 
-      installFile Cython/vcruntime140.dll "${directory}/libs"
-      installFile Cython/distutils.cfg "${directory}/lib/distutils"
-      applyPatch "Cython/PythonCygwinCCompiler.patch" "${directory}/lib/distutils" "cygwinccompiler.py" "vcruntime140"
+      findCommand wheel wheel || {
+         logMessage task "installing Wheel"
+         "${dryRun}" || executeCommand pip -q install wheel
+      }
+      logMessage task "ensuring Setuptools is up to date"
+      "${dryRun}" || executeCommand pip -q install --upgrade setuptools
+
    else
       logWarning "Python not found"
    fi
@@ -338,7 +342,7 @@ installWindowsArchive icu4c-53_1-Win32-msvc10.zip "${icuLocation}"
 
 installLibUSB0
 installLibUSB1
-installCython
+installPythonDeps
 
 "${keepFiles}" || {
    logMessage task "cleaning up"


### PR DESCRIPTION
This adds support for Python 3.11:

- Several work to make distutils behave has been removed, e..g. copying vcruntime140.dll, patching cygwinccompiler.py . When we use the most recent version of Setuptools, this is no longer needed.

I've also seen the `RuntimeWarning: Config variable 'Py_DEBUG' is unset, Python ABI tag may be incorrect` warning. I'm not sure what causes it, but I think it might have been caused by the build system using mingw32 for the build whereas it creates a wheel with msvc Python.