### PR TITLE
Support building Windows version on Appveyor

### DIFF
--- a/Windows/brltty.nsi
+++ b/Windows/brltty.nsi
@@ -35,6 +35,7 @@
 		!define DISTDIR "brltty-win-${VERSION}-${VARIANT}"
 	!endif
 
+	Unicode false
 	SetCompressor /SOLID LZMA
 	SetOverwrite IfNewer
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+###############################################################################
+# BRLTTY - A background process providing access to the console screen (when in
+#          text mode) for a blind person using a refreshable braille display.
+#
+# Copyright (C) 1995-2023 by The BRLTTY Developers.
+#
+# BRLTTY comes with ABSOLUTELY NO WARRANTY.
+#
+# This is free software, placed under the terms of the
+# GNU Lesser General Public License, as published by the Free Software
+# Foundation; either version 2.1 of the License, or (at your option) any
+# later version. Please see the file LICENSE-LGPL for details.
+#
+# Web Page: http://brltty.app/
+#
+# This software is maintained by Dave Mielke <dave@mielke.cc>.
+###############################################################################
+
+os: Visual Studio 2022
+version: "appveyor-{build}"
+branches:
+  only:
+    - master
+
+environment:
+  PY_PYTHON: 3.11-32
+
+init:
+  - ps: |
+      If (([regex]::Matches($env:APPVEYOR_BUILD_VERSION, "," )).count -eq 0) {
+       If ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+        Update-AppveyorBuild -Version ("pr$env:APPVEYOR_PULL_REQUEST_NUMBER-$env:APPVEYOR_BUILD_NUMBER-" + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8))
+       } Else {
+        Update-AppveyorBuild -Version ("$env:APPVEYOR_BUILD_VERSION-" + $env:APPVEYOR_REPO_COMMIT.Substring(0, 8))
+       }
+      }
+
+clone_depth: 1
+
+install:
+  - echo %APPVEYOR_BUILD_VERSION% > %APPVEYOR_BUILD_FOLDER%\REVISION
+  # Hack, getrevid doesn't seem to work in forks of the brltty repository.
+  # Removing .git ensures the REVISION is used.
+  - rmdir /Q /S .git
+  - cmd: |
+      C:\MinGW\msys\1.0\bin\bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; windows/winsetup"
+
+build_script:
+  - cmd: |
+      C:\MinGW\msys\1.0\bin\bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER; ./autogen; Windows/mkwin ./ $APPVEYOR_BUILD_VERSION"
+
+artifacts:
+  - path: "*.zip"
+  - path: "*.exe"


### PR DESCRIPTION
As I have been struggling for ages to get a working windows build of BRLTTY for myself, I figured building the Windows version with Continuous Integration would be most helpful.
Appveyor has baked in support for msys1, so that seemed like a good starting point, and indeed, it works like a charm.
The bundled configuration for Appveyor builds BRLTTY and uses Python 3.11 for the Python bindings. The resulting zip and installer executable are uploaded as artifacts and can be fetched from the build after building.

i have also added Unicode false to the nsis script. This is the default behavior in the version of nsis that is used by the build system by default, but Appveyor has a newer version that has Unicode set to true by default. When we change Unicode to true, we get errors with nsistrings.txt parsing.

Note that you need to setup Appveyor for this to work, which is pretty trivial:

1. Go to https://www.appveyor.com/
2. Sign in with Github
3. Create a new project from Github
4. Login with your Github credentials
5. Install the Appveyor app for the BRLTTY organization for the brltty repo.

When setup is finished, pushing a next commit to master or triggering the build from the appveyor dashboard should work. It should also work for pull requests out of the box.

note that this can be expanded in many ways, i.e:

1. Building for both versions of LibUSB
2. Building for several versions of Python
3. Building for Linux