### PR TITLE
Delete some broken ifdeffery for android.

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -58,13 +58,6 @@ Samuel Thibault <samuel.thibault@ens-lyon.org>"
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <netdb.h>
-
-#ifdef __ANDROID__
-#ifndef PAGE_SIZE
-#include <asm/page.h>
-#endif /* PAGE_SIZE */
-#endif /* __ANDROID__ */
-
 #include <pthread.h>
 
 #ifdef HAVE_SYS_SELECT_H


### PR DESCRIPTION
This deleted code is broken if the PAGE_SIZE define is removed (which it likely will be in the future), because <asm/page.h> doesn't exist in the Android NDK.

This file doesn't use PAGE_SIZE itself, but the code was originally added in 2012 in a9ed2d9ffb8ad9bd0209d2c264675d3ccf39f99c apparently as a workaround for a bug in the pthread.h header. That's certainly no longer relevant.