### PR TITLE
[HID] Support HID braille for Andorid

### DIFF
--- a/Drivers/Braille/HID/braille.c
+++ b/Drivers/Braille/HID/braille.c
@@ -1,0 +1,479 @@
+#include <jni.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "brldefs-hid.h"
+#include "third_party/brltty/Headers/bitmask.h"
+#include "third_party/brltty/Headers/brl_base.h"
+#include "third_party/brltty/Headers/brl_driver.h"
+#include "third_party/brltty/Headers/brl_types.h"
+#include "third_party/brltty/Headers/brl_utils.h"
+#include "third_party/brltty/Headers/gio_types.h"
+#include "third_party/brltty/Headers/hid_defs.h"
+#include "third_party/brltty/Headers/hid_items.h"
+#include "third_party/brltty/Headers/hid_types.h"
+#include "third_party/brltty/Headers/io_generic.h"
+#include "third_party/brltty/Headers/ktb_types.h"
+#include "third_party/brltty/Headers/log.h"
+#include "third_party/brltty/Programs/gio_internal.h"
+
+static jclass helperClass = NULL;
+
+struct BrailleDataStruct {
+  struct {
+    unsigned char count;
+    KEYS_BITMASK(mask);
+  } pressedKeys;
+
+  struct {
+    unsigned char rewrite;
+    unsigned char cells[MAX_OUTPUT_SIZE];
+  } text;
+
+  struct {
+    // The HID report ID used by both input and output. Currently expects both
+    // to be the same.
+    uint32_t reportId;
+    // The size of the HID input report.
+    uint32_t inputSizeBytes;
+    // Map each input report bit to the HID usage it represents.
+    uint32_t inputReportUsages[MAX_INPUT_SIZE];
+    // Map each input report bit to the Key (internal number) it represents.
+    uint32_t inputReportKeys[MAX_INPUT_SIZE];
+    // The first (lowest) bit number of the contiguous group of routing keys.
+    uint32_t inputRoutingFirstBit;
+  } reportInfo;
+};
+
+// Parses the Braille display's HID report descriptor, in order to understand
+// how to parse input reports and prepare output reports.
+static int probeHidDisplay(BrailleDisplay *brl, HidItemsDescriptor *items) {
+  memset(brl->data->reportInfo.inputReportUsages, 0,
+         MAX_INPUT_SIZE * sizeof(brl->data->reportInfo.inputReportUsages[0]));
+  memset(brl->data->reportInfo.inputReportKeys, 0,
+         MAX_INPUT_SIZE * sizeof(brl->data->reportInfo.inputReportKeys[0]));
+  brl->data->reportInfo.inputRoutingFirstBit = -1;
+
+  // If you'd like to print all items in the HID report then call
+  // hid_inspect#hidListItems()
+
+  // These variables save attributes from the current stack of items:
+  //   The current Usage Page.
+  uint32_t usagePage = 0;
+  //   Number of bits per usage.
+  uint32_t reportSize = 0;
+  //   Number of usages in this stack.
+  uint32_t reportCount = 0;
+  //   The Usages in this stack, stored as a list of individual usages.
+  uint32_t usages[MAX_USAGE_COUNT];
+  uint32_t usageIndex = 0;
+  //   The Usages in this stack, stored as a minimum and maximum value.
+  uint32_t usageMin = 0;
+  uint32_t usageMax = 0;
+  //   The report ID. This is implicitly zero by default, until some value
+  //   provided by the descriptor.
+  uint32_t reportId = 0;
+
+  //   The current bit of the INPUT report, used for writing to the
+  //   inputReportUsages map.
+  uint32_t inputReportBit = 0;
+
+  // These variables will be "learned" while parsing the report descriptor;
+  // set them to "unset" defaults so that parsing can detect if an inconsistency
+  // occurs.
+  //   Stores the number of output cells so that brltty knows how to prepare
+  //   output cells.
+  brl->textColumns = -1;
+  //   The report ID that will be providing Braille Display input and output.
+  brl->data->reportInfo.reportId = -1;
+
+  const unsigned char *nextByte = items->bytes;
+  size_t bytesLeft = items->count;
+  HidItem item;
+  int parsingError = 0;
+  while (1) {
+    if (!hidNextItem(&item, &nextByte, &bytesLeft)) {
+      break;
+    }
+    if (item.tag == HID_ITM_UsagePage) {
+      usagePage = item.value.u;
+    }
+    if (item.tag == HID_ITM_Collection) {
+      // Collections help differentiate between groupings of usages, e.g.
+      // between multiple rows of output braille cells. All devices we've tested
+      // so far provide their BD usages in one collection, so this driver does
+      // not yet support differentiating between collections.
+      //
+      // The type of collection would have been specified by usage items before
+      // this collection item, so reset the usage data structure (since as noted
+      // above we are ignoring collection designations).
+      usageIndex = 0;
+    }
+    if (item.tag == HID_ITM_ReportID) {
+      reportId = item.value.u;
+    }
+    if (item.tag == HID_ITM_Usage) {
+      usageMin = usageMax = -1;
+      uint32_t usage = item.value.u;
+      // TODO(b/331881337): Bug in Humanware's firmware, see
+      // https://docs.google.com/document/d/1ZuiV5h0nGHQwUnfXJRFL2-K61rO2aC_JB7UHdd5Nb_U/edit?usp=sharing&resourcekey=0-7sLXaH2DHe7l6hl5SUI0pQ.
+      // Overwrite these random "button" usages as DPad Left/Right until
+      // Humanware fixes their firmware.
+      if (usagePage == HID_UPG_Button) {
+        if (usage == 0x14) {
+          logMessage(LOG_WARNING, "Fixing Humanware nav buttons");
+          usage = HID_USG_BRL_DPadLeft;
+        }
+        if (usage == 0x15) {
+          usage = HID_USG_BRL_DPadRight;
+        }
+      }
+      usages[usageIndex++] = usage;
+    }
+    if (item.tag == HID_ITM_UsageMinimum) {
+      usageMin = item.value.u;
+    }
+    if (item.tag == HID_ITM_UsageMaximum) {
+      usageMax = item.value.u;
+    }
+    if (item.tag == HID_ITM_ReportSize) {
+      reportSize = item.value.u;
+    }
+    if (item.tag == HID_ITM_ReportCount) {
+      reportCount = item.value.u;
+    }
+    if (item.tag == HID_ITM_Input || item.tag == HID_ITM_Output ||
+        item.tag == HID_ITM_Feature) {
+      // Reset the usage index now that we're going to process the usages array.
+      usageIndex = 0;
+      // Set the BD report ID to the current reportId.
+      if (usagePage == HID_UPG_Braille) {
+        if (brl->data->reportInfo.reportId != -1 &&
+            brl->data->reportInfo.reportId != reportId) {
+          logMessage(LOG_ERR,
+                     "Found multiple report IDs that include Braille usages");
+          parsingError = 1;
+          break;
+        }
+        brl->data->reportInfo.reportId = reportId;
+      }
+    }
+
+    if (item.tag == HID_ITM_Input) {
+      if (reportId == brl->data->reportInfo.reportId) {
+        // Skip past constant bits
+        if ((item.value.u & HID_USG_FLG_CONSTANT) == HID_USG_FLG_CONSTANT) {
+          inputReportBit += reportSize * reportCount;
+          continue;
+        }
+        // Skip past usages from unexpected pages.
+        if (usagePage != HID_UPG_Braille && usagePage != HID_UPG_Button) {
+          inputReportBit += reportSize * reportCount;
+          continue;
+        }
+        // Fail if we get a usage of unexpected type or size
+        if (reportSize != 1) {
+          logMessage(LOG_ERR, "Unexpected input item input size %u != 1",
+                     reportSize);
+          parsingError = 1;
+          break;
+        }
+        if ((item.value.u & HID_USG_FLG_VARIABLE) != HID_USG_FLG_VARIABLE) {
+          logMessage(LOG_ERR, "Unexpected non-variable input item");
+          parsingError = 1;
+          break;
+        }
+        // Fail if we get a usage range that doesn't match the report count
+        if (usageMin != -1 && (usageMin + reportCount - 1) != usageMax) {
+          logMessage(LOG_ERR, "Invalid usage range: min=%u max=%u count=%u",
+                     usageMin, usageMax, reportCount);
+          parsingError = 1;
+          break;
+        }
+        if (inputReportBit > MAX_INPUT_SIZE) {
+          logMessage(LOG_ERR, "Unexpected input report with more than %u bits",
+                     MAX_INPUT_SIZE);
+          parsingError = 1;
+          break;
+        }
+        for (int i = 0; i < reportCount; i++) {
+          if (usageMin != -1) {
+            brl->data->reportInfo.inputReportUsages[inputReportBit++] =
+                usageMin++;
+          } else {
+            brl->data->reportInfo.inputReportUsages[inputReportBit++] =
+                usages[i];
+          }
+        }
+      }
+    }
+    if (item.tag == HID_ITM_Output) {
+      if (usagePage == HID_UPG_Braille) {
+        if (reportId != brl->data->reportInfo.reportId) {
+          logMessage(LOG_ERR,
+                     "Unexpected differing output and input report IDs");
+          parsingError = 1;
+          break;
+        }
+        if (usages[0] == HID_USG_BRL_6DotCell ||
+            usages[0] == HID_USG_BRL_8DotCell) {
+          if (reportSize != 8) {
+            logMessage(LOG_ERR, "Invalid output bit size %u", reportSize);
+            parsingError = 1;
+            break;
+          }
+          if (brl->textColumns != -1) {
+            logMessage(LOG_ERR,
+                       "Unexpected received multiple BD output reports");
+            parsingError = 1;
+            break;
+          }
+          brl->textColumns = reportCount;
+        }
+      }
+    }
+  }
+  free(items);
+  if (parsingError) {
+    logMessage(LOG_ERR, "There were parsing errors.");
+    return 0;
+  }
+
+  if (brl->data->reportInfo.reportId == -1) {
+    logMessage(LOG_ERR, "Could not find a Braille Display report ID");
+    return 0;
+  }
+  for (int i = 0; i < MAX_INPUT_SIZE; i++) {
+    // Uncomment this to print out the bit->usage map:
+    // logMessage(LOG_WARNING, "bit=%d report=%i", i,
+    // brl->data->reportInfo.inputReportUsages[i]);
+
+    // While parsing the descript we built up map inputReportUsages from
+    // bit->usage. However, brltty doesn't use usages to describe key events:
+    // brltty uses a key table that was provided by brl_construct. This logic
+    // builds up a new map from bit->key where the key values come from the key
+    // table that we provided to brltty. This allows the driver to map from
+    // INPUT bit to the brltty-known key name.
+    for (int j = 0; j < KEY_MAP_COUNT; j++) {
+      if (KEY_MAP[j][0] == brl->data->reportInfo.inputReportUsages[i]) {
+        brl->data->reportInfo.inputReportKeys[i] = KEY_MAP[j][1];
+      }
+    }
+    // Routing keys are handled differently. They all use the same usage,
+    // while their bit number (starting from the first one) defines the actual
+    // routing key number.
+    if (brl->data->reportInfo.inputReportUsages[i] == HID_USG_BRL_RouterKey) {
+      if (brl->data->reportInfo.inputRoutingFirstBit == -1) {
+        brl->data->reportInfo.inputRoutingFirstBit = i;
+      } else if (brl->data->reportInfo.inputReportUsages[i - 1] !=
+                 HID_USG_BRL_RouterKey) {
+        // Expect that all routing key INPUTs are sent as a contiguous group, so
+        // return error if the descriptor describes something like "... ROUTING
+        // DOT1 ROUTING ...".
+        logMessage(LOG_ERR,
+                   "Unexpected non-contiguous group of router keys at "
+                   "%d with previous entry %u and first bit %d",
+                   i, brl->data->reportInfo.inputReportUsages[i - 1],
+                   brl->data->reportInfo.inputRoutingFirstBit);
+        return 0;
+      }
+    }
+  }
+
+  int inputSizeBytes = (inputReportBit + 7) / 8;
+  int hasNumberedReport = brl->data->reportInfo.reportId != 0;
+  if (hasNumberedReport != 0) {
+    // The first byte of input should contain the report ID, then all other
+    // bytes should be parsed as input.
+    brl->data->reportInfo.inputSizeBytes = inputSizeBytes + 1;
+  } else {
+    // The entire input report should be parsed as input.
+    brl->data->reportInfo.inputSizeBytes = inputSizeBytes;
+  }
+  // Zero-out the input key mask used to track the current state of input key
+  // presses.
+  BITMASK_ZERO(brl->data->pressedKeys.mask);
+  return 1;
+}
+
+// Enqueues a key event to brltty's internal key processing logic.
+// brltty waits for all keys to be released, then looks at the combined set of
+// key-down events to understand what key combination was pressed by looking
+// up possible key combinations from the HID.ktb keytable.
+static int handleKeyEvent(BrailleDisplay *brl, unsigned char key, int press) {
+  KeyGroup group;
+  if (key < HID_KEY_ROUTING) {
+    group = HID_GRP_NavigationKeys;
+  } else {
+    group = HID_GRP_RoutingKeys;
+    key -= HID_KEY_ROUTING;
+  }
+  return enqueueKeyEvent(brl, group, key, press);
+}
+
+// Possibly enqueues a key-down action.
+static int handleKeyPress(BrailleDisplay *brl, unsigned char key) {
+  if (BITMASK_TEST(brl->data->pressedKeys.mask, key)) return 0;
+
+  BITMASK_SET(brl->data->pressedKeys.mask, key);
+  brl->data->pressedKeys.count += 1;
+
+  handleKeyEvent(brl, key, 1);
+  return 1;
+}
+
+// Possibly enqueues a key-action action.
+static int handleKeyRelease(BrailleDisplay *brl, unsigned char key) {
+  if (!BITMASK_TEST(brl->data->pressedKeys.mask, key)) return 0;
+
+  BITMASK_CLEAR(brl->data->pressedKeys.mask, key);
+  brl->data->pressedKeys.count -= 1;
+
+  handleKeyEvent(brl, key, 0);
+  return 1;
+}
+
+// Parses a HID input report into brltty key actions.
+// Called by brltty when it wants to parse an input byte array.
+static void handlePressedKeysArray(BrailleDisplay *brl, unsigned char *keys) {
+  unsigned int currentPressedKeyCount = 0;
+
+  // Per HIDRAW spec if input descriptor report number is not zero then the
+  // first byte in the input should be the report number.
+  int hasNumberedReport = brl->data->reportInfo.reportId != 0;
+  if (hasNumberedReport && keys[0] != brl->data->reportInfo.reportId) {
+    logMessage(LOG_WARNING, "Unexpected input report %u", keys[0]);
+    return;
+  }
+
+  int numInputBytes = hasNumberedReport
+                          ? brl->data->reportInfo.inputSizeBytes - 1
+                          : brl->data->reportInfo.inputSizeBytes;
+  const unsigned char *byte = hasNumberedReport ? keys + 1 : keys;
+  for (int byteNum = 0; byteNum < numInputBytes; byteNum++) {
+    for (int bit = 0; bit <= 7; bit++) {
+      int bitNum = byteNum * 8 + bit;
+      if ((*byte) & (1 << bit)) {
+        // Uncomment this to see which bits are raised in the INPUT report.
+        // logMessage(LOG_WARNING, "Pressed bit %d usage %u",
+        //            bitNum, brl->data->reportInfo.inputReportUsages[bitNum]);
+        char key;
+        if (brl->data->reportInfo.inputReportUsages[bitNum] ==
+            HID_USG_BRL_RouterKey) {
+          int routingKeyNum =
+              bitNum - brl->data->reportInfo.inputRoutingFirstBit;
+          key = HID_KEY_ROUTING + routingKeyNum;
+        } else {
+          key = brl->data->reportInfo.inputReportKeys[bitNum];
+        }
+        if (key != 0) {
+          currentPressedKeyCount += 1;
+          handleKeyPress(brl, key);
+        }
+      }
+    }
+    byte++;
+  }
+
+  if (brl->data->pressedKeys.count > currentPressedKeyCount) {
+    for (unsigned int key = 0; key <= MAXIMUM_KEY_VALUE; key++) {
+      if (handleKeyRelease(brl, key)) {
+        if (brl->data->pressedKeys.count == currentPressedKeyCount) {
+          break;
+        }
+      }
+    }
+  }
+}
+
+static int writeHidCells(BrailleDisplay *brl, const unsigned char *cells,
+                         unsigned char cellCount) {
+  // HIDRAW expects the report ID in the first byte, followed by the
+  // output report.
+  int bufferSize = cellCount + 1;
+  unsigned char buffer[bufferSize];
+  buffer[0] = brl->data->reportInfo.reportId;
+  memcpy(buffer + 1, cells, cellCount);
+  return brl->gioEndpoint->handleMethods->writeData(
+      brl->gioEndpoint->handle, buffer, bufferSize, /*timeout=*/0);
+}
+
+// Standard functions expected by brltty for any brltty driver. These were
+// essentially copied the Humanware driver with minimal modifications.
+
+static int connectResource(BrailleDisplay *brl, const char *identifier) {
+  static const HidModelEntry hidModelTable[] = {
+      {
+          // Model name is not used to control driver behavior, so always
+          // expect "HID" as set by hid_android.c#getGenericHIDDeviceName().
+          .name = "HID",
+      },
+      {.name = NULL, .vendor = 0}};
+
+  GioDescriptor descriptor;
+  gioInitializeDescriptor(&descriptor);
+  descriptor.hid.modelTable = hidModelTable;
+
+  return connectBrailleResource(brl, identifier, &descriptor, NULL) ? 1 : 0;
+}
+
+static int brl_construct(BrailleDisplay *brl, char **parameters,
+                         const char *device) {
+  if ((brl->data = malloc(sizeof(*brl->data)))) {
+    memset(brl->data, 0, sizeof(*brl->data));
+
+    if (connectResource(brl, device)) {
+      HidItemsDescriptor *items = brl->gioEndpoint->handleMethods->getHidDescriptor(
+              brl->gioEndpoint->handle);
+      if (probeHidDisplay(brl, items)) {
+        setBrailleKeyTable(brl, &keyTableDefinition_HID);
+        makeOutputTable(dotsTable_ISO11548_1);
+        brl->data->text.rewrite = 1;
+        return 1;
+      }
+      disconnectBrailleResource(brl, NULL);
+    }
+    free(brl->data);
+    brl->data = NULL;
+  } else {
+    logMallocError();
+  }
+  return 0;
+}
+
+static void brl_destruct(BrailleDisplay *brl) {
+  disconnectBrailleResource(brl, NULL);
+  free(brl->data);
+}
+
+// Called by brltty when it wants to write output to the Braille display.
+static int brl_writeWindow(BrailleDisplay *brl, const wchar_t *text) {
+  const size_t count = brl->textColumns;
+  if (cellsHaveChanged(brl->data->text.cells, brl->buffer, count, NULL, NULL,
+                       &brl->data->text.rewrite)) {
+    unsigned char cells[count];
+
+    translateOutputCells(cells, brl->data->text.cells, count);
+    if (!writeHidCells(brl, cells, count)) return 0;
+  }
+  return 1;
+}
+
+static int brl_readCommand(BrailleDisplay *brl,
+                           KeyTableCommandContext context) {
+  unsigned char packet[MAX_INPUT_SIZE];
+  while (1) {
+    size_t length = brl->gioEndpoint->handleMethods->readData(
+        brl->gioEndpoint->handle, packet, MAX_INPUT_SIZE,
+        /*initialTimeout unused*/ 0, /*subsequentTimeout unused*/ 0);
+    if (length == 0) {
+      break;
+    }
+    handlePressedKeysArray(brl, packet);
+  }
+  return EOF;
+}
+

--- a/Drivers/Braille/HID/braille.c
+++ b/Drivers/Braille/HID/braille.c
@@ -118,8 +118,6 @@ static int probeHidDisplay(BrailleDisplay *brl, HidItemsDescriptor *items) {
     if (item.tag == HID_ITM_Usage) {
       usageMin = usageMax = -1;
       uint32_t usage = item.value.u;
-      // TODO(b/331881337): Bug in Humanware's firmware, see
-      // https://docs.google.com/document/d/1ZuiV5h0nGHQwUnfXJRFL2-K61rO2aC_JB7UHdd5Nb_U/edit?usp=sharing&resourcekey=0-7sLXaH2DHe7l6hl5SUI0pQ.
       // Overwrite these random "button" usages as DPad Left/Right until
       // Humanware fixes their firmware.
       if (usagePage == HID_UPG_Button) {

--- a/Drivers/Braille/HID/brldefs-hid.h
+++ b/Drivers/Braille/HID/brldefs-hid.h
@@ -1,0 +1,86 @@
+
+#ifndef BRLTTY_INCLUDED_HID_BRLDEFS
+#define BRLTTY_INCLUDED_HID_BRLDEFS
+#include "third_party/brltty/Headers/hid_defs.h"
+#include "third_party/brltty/Headers/ktb_types.h"
+#define MAX_INPUT_SIZE 0XFF
+#define MAX_OUTPUT_SIZE 0XFF
+#define MAX_USAGE_COUNT 0xFF
+#define MAXIMUM_KEY_VALUE 0XFF
+#define KEYS_BITMASK(name) BITMASK(name, (MAXIMUM_KEY_VALUE + 1), int)
+// Enum of Key values that are used by the KEYS_BITMASK in order to track
+// which keys are currently pressed. The specific values are meaningless and
+// only serve as a temporary identifier in the input parsing logic.
+typedef enum {
+  HID_KEY_Dot1 = 1,
+  HID_KEY_Dot2,
+  HID_KEY_Dot3,
+  HID_KEY_Dot4,
+  HID_KEY_Dot5,
+  HID_KEY_Dot6,
+  HID_KEY_Dot7,
+  HID_KEY_Dot8,
+  HID_KEY_Space,
+  HID_KEY_PanLeft,
+  HID_KEY_PanRight,
+  HID_KEY_DPadUp,
+  HID_KEY_DPadDown,
+  HID_KEY_DPadLeft,
+  HID_KEY_DPadRight,
+  HID_KEY_DPadCenter,
+  HID_KEY_RockerUp,
+  HID_KEY_RockerDown,
+  HID_KEY_ROUTING,
+} HID_Keys;
+// Maps from official Braille Display HID usages to the custom Key enum.
+int KEY_MAP[][2] = {
+    {HID_USG_BRL_KeyboardDot1, HID_KEY_Dot1},
+    {HID_USG_BRL_KeyboardDot2, HID_KEY_Dot2},
+    {HID_USG_BRL_KeyboardDot3, HID_KEY_Dot3},
+    {HID_USG_BRL_KeyboardDot4, HID_KEY_Dot4},
+    {HID_USG_BRL_KeyboardDot5, HID_KEY_Dot5},
+    {HID_USG_BRL_KeyboardDot6, HID_KEY_Dot6},
+    {HID_USG_BRL_KeyboardDot7, HID_KEY_Dot7},
+    {HID_USG_BRL_KeyboardDot8, HID_KEY_Dot8},
+    {HID_USG_BRL_KeyboardSpace, HID_KEY_Space},
+    {HID_USG_BRL_PanLeft, HID_KEY_PanLeft},
+    {HID_USG_BRL_PanRight, HID_KEY_PanRight},
+    {HID_USG_BRL_DPadUp, HID_KEY_DPadUp},
+    {HID_USG_BRL_DPadDown, HID_KEY_DPadDown},
+    {HID_USG_BRL_DPadLeft, HID_KEY_DPadLeft},
+    {HID_USG_BRL_DPadRight, HID_KEY_DPadRight},
+    {HID_USG_BRL_DPadCenter, HID_KEY_DPadCenter},
+    {HID_USG_BRL_RockerUp, HID_KEY_RockerUp},
+    {HID_USG_BRL_RockerDown, HID_KEY_RockerDown},
+    // Router keys are handled separately.
+};
+int KEY_MAP_COUNT = sizeof(KEY_MAP) / sizeof(KEY_MAP[0]);
+typedef enum { HID_GRP_NavigationKeys = 0, HID_GRP_RoutingKeys } HID_KEYGroup;
+// Maps from the Key enum to a textual Key name used by the HID.ktb keytable.
+static const KeyNameEntry keyNameTable[] = {
+    {.value.number = HID_KEY_Dot1, .name = "Dot1"},
+    {.value.number = HID_KEY_Dot2, .name = "Dot2"},
+    {.value.number = HID_KEY_Dot3, .name = "Dot3"},
+    {.value.number = HID_KEY_Dot4, .name = "Dot4"},
+    {.value.number = HID_KEY_Dot5, .name = "Dot5"},
+    {.value.number = HID_KEY_Dot6, .name = "Dot6"},
+    {.value.number = HID_KEY_Dot7, .name = "Dot7"},
+    {.value.number = HID_KEY_Dot8, .name = "Dot8"},
+    {.value.number = HID_KEY_Space, .name = "Space"},
+    {.value.number = HID_KEY_PanLeft, .name = "PanLeft"},
+    {.value.number = HID_KEY_PanRight, .name = "PanRight"},
+    {.value.number = HID_KEY_DPadUp, .name = "DPadUp"},
+    {.value.number = HID_KEY_DPadDown, .name = "DPadDown"},
+    {.value.number = HID_KEY_DPadLeft, .name = "DPadLeft"},
+    {.value.number = HID_KEY_DPadRight, .name = "DPadRight"},
+    {.value.number = HID_KEY_DPadCenter, .name = "DPadCenter"},
+    {.value.number = HID_KEY_RockerUp, .name = "RockerUp"},
+    {.value.number = HID_KEY_RockerDown, .name = "RockerDown"},
+    {.value = {.group = HID_GRP_RoutingKeys, .number = KTB_KEY_ANY},
+     .name = "RoutingKey"},
+    {.name = NULL}};
+static const KeyNameEntry *const keyNameTables_HID[] = {keyNameTable, NULL};
+static const KeyTableDefinition keyTableDefinition_HID = {
+    .bindings = "HID", .names = keyNameTables_HID};
+#endif /* BRLTTY_INCLUDED_HID_BRLDEFS */
+

--- a/Programs/gio.c
+++ b/Programs/gio.c
@@ -28,6 +28,7 @@
 #include "io_generic.h"
 #include "gio_internal.h"
 #include "io_serial.h"
+#include "hid_types.h"
 
 const GioProperties *const gioProperties[] = {
   &gioProperties_serial,
@@ -487,6 +488,27 @@ gioAskResource (
                 endpoint->options.requestTimeout);
 }
 
+HidReportIdentifier *
+gioGetHidDescriptorMethod (
+  GioEndpoint *endpoint) {
+  GioGetHidDescriptorMethod *method = endpoint->handleMethods->getHidDescriptor;
+
+  if (!method) {
+    logUnsupportedOperation("getHidDescriptor");
+    errno = ENOSYS;
+    return 0;
+  }
+
+  return method(
+    endpoint->handle
+  );
+
+  logMessage(LOG_WARNING, "HID DESCRIPTOR not found");
+  return NULL;
+}
+  
+  
+  
 int
 gioGetHidReportSize (
   GioEndpoint *endpoint,

--- a/Programs/gio_hid.c
+++ b/Programs/gio_hid.c
@@ -92,6 +92,12 @@ getHidReportSize (
   return hidGetReportSize(handle->device, identifier, size);
 }
 
+static HidReportIdentifier *
+getHidDescriptor (GioHandle *handle
+) {
+  return hidGetItems(handle->device);
+}
+
 static ssize_t
 getHidReport (
   GioHandle *handle, HidReportIdentifier identifier,
@@ -159,6 +165,7 @@ static const GioHandleMethods gioHidMethods = {
   .monitorInput = monitorHidInput,
 
   .getHidReportSize = getHidReportSize,
+  .getHidDescriptor = getHidDescriptor,
   .getHidReport = getHidReport,
   .setHidReport = setHidReport,
   .getHidFeature = getHidFeature,

--- a/Programs/gio_internal.h
+++ b/Programs/gio_internal.h
@@ -60,6 +60,10 @@ typedef ssize_t GioAskResourceMethod (
   void *buffer, uint16_t size, int timeout
 );
 
+typedef HidReportIdentifier *GioGetHidDescriptorMethod(
+  GioHandle *handle
+);
+
 typedef int GioGetHidReportSizeMethod (
   GioHandle *handle, HidReportIdentifier identifier,
   HidReportSize *size, int timeout
@@ -103,6 +107,7 @@ typedef struct {
   GioAskResourceMethod *askResource;
 
   GioGetHidReportSizeMethod *getHidReportSize;
+  GioGetHidDescriptorMethod *getHidDescriptor;
   GioGetHidReportMethod *getHidReport;
   GioSetHidReportMethod *setHidReport;
   GioGetHidFeatureMethod *getHidFeature;

--- a/Tables/Input/HID/HID.ktb
+++ b/Tables/Input/HID/HID.ktb
@@ -1,0 +1,35 @@
+title Generic HID Braille Display
+note These files must be placed in a directory named 'hid' to be loaded properly by brltty
+
+include ../chords.kti
+
+bind RoutingKey ROUTE:ROUTE+128
+
+note Panning and Rocker keys
+note     PanLeft/RockerUp move the Braille cell window left
+note     PanRight/RockerDown move the Braille cell window right
+assign panLeft PanLeft
+bind \{panLeft} FWINLT
+assign panRight PanRight
+bind \{panRight} FWINRT
+assign rockerUp RockerUp
+bind \{rockerUp} FWINLT
+assign rockerDown RockerDown
+bind \{rockerDown} FWINRT
+
+note D-Pad
+note     DPadLeft moves to previous item, DPadRight moves to next item
+note     DPadUp moves up a line, DPadDown moves down a line
+note     DPadCenter is KEY_ENTER
+assign dpadLeft DPadLeft
+bind \{dpadLeft} CHRLT
+assign dpadRight DPadRight
+bind \{dpadRight} CHRRT
+assign dpadLeft DPadUp
+bind \{dpadLeft} LNUP
+assign dpadRight DPadDown
+bind \{dpadRight} LNDN
+assign dpadCenter DPadCenter
+bind \{dpadCenter} KEY_ENTER
+
+include ../android-chords.kti


### PR DESCRIPTION
We have developed Android support for HID. We're leveraging Linux's hid-raw and new Android APIs to enable communication between Android and HID-based braille display. 

The changes can't be completed in a single CL because we are waiting on the new Android API to be published. The design may differ from existing designs. Feel free to modify it to ensure compatibility with BRLTTY.

This change contains:

- Drivers/Braille/HID/braille.c
- Drivers/Braille/HID/brldefs-hid.h
- Programs/gio.h
- Programs/gio-hid.c
- Programs/gio-internal.h
- Tables/HID/HID.ktb

We handle all HID-supported devices with a single driver. You'll find this driver within the 'Drivers/Braille/HID' folder.
The braille.c file implements the generic HID (0x41) braille display driver. It uses new Android's API to get device-specific HID report descriptors then parses the descriptor to determine how to interpret input reports and generate appropriate output reports. HID.ktb is a generic table that supports all HID-compatible braille displays.