### PR TITLE
Fix builds on Solaris with gcc 14

### DIFF
--- a/Programs/Makefile.in
+++ b/Programs/Makefile.in
@@ -766,7 +766,7 @@ cldr.$O:
 ###############################################################################
 
 rgx.$O:
-	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/rgx.c
+	$(CC) $(LIBCFLAGS) $(RGX_INCLUDES) -c $(SRC_DIR)/rgx.c
 
 $(RGX_OBJECT).$O:
 	$(CC) $(LIBCFLAGS) $(RGX_INCLUDES) -c $(SRC_DIR)/$(RGX_OBJECT).c

--- a/Programs/brlapi_client.c
+++ b/Programs/brlapi_client.c
@@ -38,6 +38,10 @@
 #include <limits.h>
 #include <unistd.h>
 
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif /* HAVE_ALLOCA_H */
+
 #ifndef __MINGW32__
 #ifdef HAVE_LANGINFO_H
 #include <langinfo.h>

--- a/Programs/file.c
+++ b/Programs/file.c
@@ -40,6 +40,10 @@
 #include <sys/file.h>
 #endif /* HAVE_SYS_FILE_H */
 
+#ifdef HAVE_TERMIOS_H
+#include <termios.h>
+#endif /* HAVE_TERMIOS_H */
+
 #include "parameters.h"
 #include "log.h"
 #include "strfmt.h"

--- a/Programs/usb_solaris.c
+++ b/Programs/usb_solaris.c
@@ -27,6 +27,7 @@
 #include <sys/usb/clients/ugen/usb_ugen.h>
 
 #include "log.h"
+#include "bitfield.h"
 #include "io_usb.h"
 #include "usb_internal.h"
 

--- a/config.h.in
+++ b/config.h.in
@@ -316,6 +316,9 @@ extern "C" {
 /* Define this if the header file syslog.h exists. */
 #undef HAVE_SYSLOG_H
 
+/* Define this if the header file termios.h exists. */
+#undef HAVE_TERMIOS_H
+
 /* Define this if the header file wchar.h exists. */
 #undef HAVE_WCHAR_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -939,7 +939,7 @@ AC_CHECK_HEADERS([linux/seccomp.h linux/filter.h linux/audit.h])
 AC_CHECK_HEADERS([signal.h sys/signalfd.h])
 AC_CHECK_FUNCS([sigaction])
 
-AC_CHECK_HEADERS([alloca.h getopt.h regex.h])
+AC_CHECK_HEADERS([alloca.h getopt.h regex.h termios.h])
 AC_CHECK_HEADERS([syslog.h])
 AC_CHECK_HEADERS([sys/file.h sys/socket.h])
 AC_CHECK_HEADERS([pwd.h grp.h])


### PR DESCRIPTION
gcc 14 is stricter about making sure you include the proper headers and turned several things that used to just be warnings into errors.  These patches fix the ones I hit building from git on Solaris 11.4.  

- `file.c`: include `termios.h` if the system has it
- `usb_solaris.c`: include `bitfield.h` for definition of `putLittleEndian16`
- `rgx.c`: Use `RGX_INCLUDES` when building, in order to find `pcre2.h`
- `brlapi_client.c`: include `alloca.h` if the system has it
