### PR TITLE
Add the address parameter to the speech-dispatcher speech driver

### DIFF
--- a/Documents/brltty.conf.in
+++ b/Documents/brltty.conf.in
@@ -429,6 +429,7 @@
 #speech-parameters mp:Pitch=0 # [-10-10]
 
 # SpeechDispatcher Speech Driver Parameters
+#speech-parameters sd:Address= # [address of speech-dispatcher's server]
 #speech-parameters sd:Autospawn= # [yes,no]
 #speech-parameters sd:Language= # [two-letter language code]
 #speech-parameters sd:Module= # [flite,festival,epos-generic,dtk-generic,...]

--- a/Drivers/Speech/SpeechDispatcher/README
+++ b/Drivers/Speech/SpeechDispatcher/README
@@ -18,6 +18,7 @@ search paths for their internal dependencies.
 This driver recognizes the following parameters:
 
    Parameter Settings
+   address   address of speech-dispatcher's server
    autospawn yes,no
    module    name (flite, festival, epos-generic, dtk-generic, ...)
    language  two-letter language code

--- a/Drivers/Speech/SpeechDispatcher/speech.c
+++ b/Drivers/Speech/SpeechDispatcher/speech.c
@@ -25,13 +25,14 @@
 #include "parse.h"
 
 typedef enum {
+  PARM_ADDRESS,
   PARM_AUTOSPAWN,
   PARM_MODULE,
   PARM_LANGUAGE,
   PARM_VOICE,
   PARM_NAME
 } DriverParameter;
-#define SPKPARMS "autospawn", "module", "language", "voice", "name"
+#define SPKPARMS "address", "autospawn", "module", "language", "voice", "name"
 
 #include "spk_driver.h"
 
@@ -195,6 +196,10 @@ spk_construct (SpeechSynthesizer *spk, char **parameters) {
   spk->setPunctuation = spk_setPunctuation;
 
   clearSettings();
+
+  if (parameters[PARM_ADDRESS] && *parameters[PARM_ADDRESS]) {
+    setenv("SPEECHD_ADDRESS", parameters[PARM_ADDRESS], 0);
+  }
 
   if (parameters[PARM_AUTOSPAWN] && *parameters[PARM_AUTOSPAWN]) {
     if (!validateYesNo(&autospawn, parameters[PARM_AUTOSPAWN])) {


### PR DESCRIPTION
This subsumes the removed port parameter.

If the address parameter is passed to the driver, its contents gets
put in the SPEECHD_ADDRESS environment vriable so that libspeechd
can use it. If the environment variable has already been set, the
driver parameter does not overwrite it.

This implements a suggestion from @sthibaul