### PR TITLE
brlapi: Flush output on client leaving a tty

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -1052,6 +1052,8 @@ static void doLeaveTty(Connection *c)
   unlockMutex(&apiConnectionsMutex);
   freeKeyrangeList(&c->acceptedKeys);
   freeBrailleWindow(&c->brailleWindow);
+  /* We may have to uncover some output below */
+  flushOutput();
 }
 
 static int handleLeaveTtyMode(Connection *c, brlapi_packetType_t type, brlapi_packet_t *packet, size_t size)


### PR DESCRIPTION
Since that may uncover some writes of a client attached to a tty below it, we should show that immediately and not have to wait for an update.