### PR TITLE
Start the graphical BRLTTY like the root one

### DIFF
--- a/Autostart/X11/90xbrlapi.in
+++ b/Autostart/X11/90xbrlapi.in
@@ -6,6 +6,7 @@ drivers_directory="@drivers_directory@"
 program_directory="@program_directory@"
 xbrlapi="$program_directory/xbrlapi"
 brltty="$program_directory/brltty"
+xbrltty_flags="-b ba -x a2 -N"
 
 if [ -x "${xbrlapi}" ]; then
   if "${xbrlapi}" 2>/dev/null ; then
@@ -13,7 +14,7 @@ if [ -x "${xbrlapi}" ]; then
     if [ -x "${brltty}" -a \
          -e "$drivers_directory/libbrlttybba.so" -a \
          -e "$drivers_directory/libbrlttyxa2.so" ]; then
-      "${brltty}" -b ba -s no -x a2 -N 2>/dev/null
+      "${brltty}" ${xbrltty_flags} 2>/dev/null
     fi
   fi
 fi


### PR DESCRIPTION
The instance of BRLTTY that follows graphical screens was run with
both speech support and BrlAPI server disabled. This commit removes these
hard-coded assumptions from the startup script.

@sthibaul any opinion on the change about `-N`?

Actually I see no reason why the BrlAPI server should be disabled for the X
brltty?

For the speech driver, disabling it for graphical BRLTTY definitely feels
wrong, as if a user
uses speech in the text consoles it is very likley that they will want to
have it in graphical terminals,
too.