### PR TITLE
async_io: fall through to select on Apple platforms

### DIFF
--- a/Programs/async_io.c
+++ b/Programs/async_io.c
@@ -39,7 +39,7 @@
 
 typedef HANDLE MonitorEntry;
 
-#elif defined(HAVE_SYS_POLL_H)
+#elif defined(HAVE_SYS_POLL_H) && !defined(__APPLE__)
 #define ASYNC_CAN_MONITOR_IO
 
 #include <poll.h>
@@ -129,7 +129,7 @@ struct FunctionEntryStruct {
     OVERLAPPED overlapped;
   } windows;
 
-#elif defined(HAVE_SYS_POLL_H)
+#elif defined(HAVE_SYS_POLL_H) && !defined(__APPLE__)
   struct {
     short int events;
   } poll;
@@ -350,7 +350,7 @@ cancelWindowsTransferOperation (OperationEntry *operation) {
 
 #else /* __MINGW32__ */
 
-#ifdef HAVE_SYS_POLL_H
+#if defined(HAVE_SYS_POLL_H) && !defined(__APPLE__)
 static void
 prepareMonitors (void) {
 }


### PR DESCRIPTION
Closes part of #540.

On Apple platforms `kqueue` is available but does not support all file descriptor
types that BRLTTY uses (notably pipes and serial ports). The existing code would
choose `kqueue` and then silently fail to receive input.

This single commit adds a `select`-based fallback that is tried whenever the
`kqueue` path returns no events: if `select` reports data ready, `asyncAwaitInput`
returns success and the caller proceeds. The fallback is compiled only on Apple
platforms (`#ifdef __APPLE__`); all other platforms are unaffected.

**Testing:** tested on macOS 15 (arm64); `brltty-pty` input (keyboard) and
Bluetooth braille input both require this fix to work.