### PR TITLE
bluetooth_darwin: implement bthMonitorInput using async_io

### DIFF
--- a/Programs/bluetooth_darwin.c
+++ b/Programs/bluetooth_darwin.c
@@ -31,6 +31,7 @@
 #include "io_bluetooth.h"
 #include "bluetooth_internal.h"
 #include "system_darwin.h"
+#include "async_io.h"
 
 @interface ServiceQueryResult: AsynchronousResult
 - (void) sdpQueryComplete
@@ -256,7 +257,7 @@ bthDiscoverChannel (
 
 int
 bthMonitorInput (BluetoothConnection *connection, AsyncMonitorCallback *callback, void *data) {
-  return 0;
+  return asyncMonitorFileInput(NULL, connection->extension->inputPipe[0], callback, data);
 }
 
 int


### PR DESCRIPTION
Closes part of #540.

The macOS Bluetooth driver (bluetooth_darwin) was missing an implementation of bthMonitorInput, so braille key presses over Bluetooth were never delivered to BRLTTY. This commit implements it using BRLTTY's existing asyncMonitorFileInput infrastructure (the same mechanism used by the USB and serial drivers).

Depends on the select fallback in #541 to work correctly on macOS.

**Testing:** tested on macOS 15 (arm64) with a Focus Blue 5th-generation display connected over Bluetooth.