### PR TITLE
brltty-pty: render by passing child output through to the terminal

### DIFF
--- a/Documents/brltty-pty.1.in
+++ b/Documents/brltty-pty.1.in
@@ -1,0 +1,108 @@
+.\" @configure_input@
+.\"
+.\" BRLTTY - A background process providing access to the console screen (when in
+.\"          text mode) for a blind person using a refreshable braille display.
+.\"
+.\" Copyright (C) 1995-2026 by The BRLTTY Developers.
+.\"
+.\" BRLTTY comes with ABSOLUTELY NO WARRANTY.
+.\"
+.\" This is free software, placed under the terms of the
+.\" GNU Lesser General Public License, as published by the Free Software
+.\" Foundation; either version 2.1 of the License, or (at your option) any
+.\" later version. Please see the file LICENSE-LGPL for details.
+.\"
+.\" Web Page: http://brltty.app/
+.\"
+.\" This software is maintained by Dave Mielke <dave@mielke.cc>.
+.TH "BRLTTY-PTY" "1" "June 2026" "@PACKAGE_TARNAME@ @PACKAGE_VERSION@" "@PACKAGE_NAME@ User's Manual"
+.SH NAME
+brltty-pty \- run a terminal within a pty and export its screen to BRLTTY
+.SH SYNOPSIS
+\fBbrltty-pty\fR [\fIoption\fR ...] [\fIcommand\fR [\fIargument\fR ...]]
+.SH DESCRIPTION
+.B brltty-pty
+runs a shell (or a terminal manager such as
+.B tmux
+or
+.BR screen )
+within a pseudo-terminal, interprets that terminal's output into a screen image,
+and exports the image through a shared-memory segment so that
+.B BRLTTY
+can read it via its Terminal Emulator
+.RB ( em )
+screen driver.
+This lets a braille user reach a terminal that runs inside a graphical terminal
+emulator (for example macOS Terminal.app or iTerm2), where the system console
+screen driver does not apply.
+.PP
+It is normally started by the
+.B brltty-term
+launcher, which runs it together with
+.BR brltty 's
+Terminal Emulator screen driver, but it can also be run directly.
+.PP
+If no
+.I command
+is given, the user's login shell is run.
+.PP
+When a program inside the terminal emits an
+.B OSC 52
+sequence (a request to copy),
+.B brltty-pty
+writes the text to the host clipboard (on macOS, the pasteboard). An
+.B OSC 52
+read request is declined for privacy.
+.SH OPTIONS
+.TP
+\fB-x\fR (\fB--driver-directives\fR)
+Write driver directives to standard error.
+.TP
+\fB-p\fR (\fB--show-path\fR)
+Show the absolute path to the pty slave.
+.TP
+\fB-u\fR \fIuser\fR (\fB--user=\fR)
+The name or number of the user to run as.
+.TP
+\fB-g\fR \fIgroup\fR (\fB--group=\fR)
+The name or number of the group to run as.
+.TP
+\fB-d\fR \fIpath\fR (\fB--working-directory=\fR)
+The directory to change to.
+.TP
+\fB-D\fR \fIpath\fR (\fB--home-directory=\fR)
+The home directory to use.
+.TP
+\fB-I\fR (\fB--log-input\fR)
+Log input written to the pty slave.
+.TP
+\fB-O\fR (\fB--log-output\fR)
+Log output received from the pty slave that isn't an escape sequence or a
+special character.
+.TP
+\fB-S\fR (\fB--log-sequences\fR)
+Log escape sequences and special characters received from the pty slave.
+.TP
+\fB-U\fR (\fB--log-unexpected\fR)
+Log unexpected input/output.
+.TP
+\fB-h\fR (\fB--help\fR)
+Print a command line usage summary and then exit.
+.TP
+\fB-H\fR (\fB--full-help\fR)
+Print a thorough command line usage summary and then exit.
+.SH ENVIRONMENT
+.TP
+.B BRLTTY_PTY_CLIPBOARD_FILE
+If set, a copy is written to this file instead of the host clipboard. This is a
+fork-free way to wire up a custom clipboard (for example a fifo paired with
+.B xclip
+or
+.BR wl-copy ).
+.SH "SEE ALSO"
+.BR brltty (1)
+.PP
+For full documentation, see
+.BR BRLTTY 's
+on-line manual at
+.RB "[" "http://brltty.app/documentation.html" "]."

--- a/Documents/brltty-pty.1.in
+++ b/Documents/brltty-pty.1.in
@@ -46,13 +46,15 @@ If no
 .I command
 is given, the user's login shell is run.
 .PP
-When a program inside the terminal emits an
+When text is copied \- either with
+.BR BRLTTY 's
+braille copy commands, or by a program inside the terminal that emits an
 .B OSC 52
-sequence (a request to copy),
+sequence \-
 .B brltty-pty
-writes the text to the host clipboard (on macOS, the pasteboard). An
-.B OSC 52
-read request is declined for privacy.
+publishes it to the host clipboard. See
+.B ENVIRONMENT
+below for how that is done.
 .SH OPTIONS
 .TP
 \fB-x\fR (\fB--driver-directives\fR)
@@ -93,12 +95,39 @@ Print a command line usage summary and then exit.
 Print a thorough command line usage summary and then exit.
 .SH ENVIRONMENT
 .TP
+.B BRLTTY_PTY_CLIPBOARD_MODE
+How a copy is published to the host clipboard: one of
+.BR native ", " passthrough ", or " auto
+(the default).
+In
+.B native
+mode the host clipboard is written directly (on macOS, the pasteboard) - this
+reaches the clipboard regardless of the terminal and works even under
+.BR screen / tmux .
+In
+.B passthrough
+mode the copy is re-emitted to the outer terminal as an
+.B OSC 52
+sequence for that terminal to publish (as
+.BR tmux 's
+.B set-clipboard on
+does), which is the only way to reach the clipboard over
+.BR ssh .
+.B auto
+uses native when a local pasteboard is reachable, and passthrough when running
+remotely (detected via
+.BR SSH_CONNECTION / SSH_TTY )
+or where no native backend exists; a failed native write also falls back to
+passthrough.
+.TP
 .B BRLTTY_PTY_CLIPBOARD_FILE
 If set, a copy is written to this file instead of the host clipboard. This is a
 fork-free way to wire up a custom clipboard (for example a fifo paired with
 .B xclip
 or
-.BR wl-copy ).
+.BR wl-copy ),
+and it takes precedence over
+.BR BRLTTY_PTY_CLIPBOARD_MODE .
 .SH "SEE ALSO"
 .BR brltty (1)
 .PP

--- a/Drivers/Screen/TerminalEmulator/screen.c
+++ b/Drivers/Screen/TerminalEmulator/screen.c
@@ -32,6 +32,9 @@
 #include "async_handle.h"
 #include "async_io.h"
 #include "embed.h"
+#include "report.h"
+#include "clipboard.h"
+#include "brlapi_param.h"
 
 typedef enum {
   PARM_DIRECTORY,
@@ -116,6 +119,34 @@ messageHandler_emulatorExiting (const MessageHandlerParameters *parameters) {
   handleException("emulator exiting");
 }
 
+/* BRLTTY clipboard -> host clipboard bridging, driver side. We own BRLTTY's
+ * clipboard; the emulator (in the GUI session) owns the system clipboard. When a
+ * braille copy changes BRLTTY's clipboard, push the new text out to the emulator
+ * to publish to the host. (The reverse direction is intentionally not bridged:
+ * the host clipboard is already reachable in the terminal via the GUI's own
+ * paste.) */
+static ReportListenerInstance *clipboardReportListener = NULL;
+
+static
+REPORT_LISTENER(clipboardParameterListener) {
+  const ApiParameterUpdatedReport *report = parameters->reportData;
+  if (report->parameter != BRLAPI_PARAM_CLIPBOARD_CONTENT) return;
+
+  char *content = getMainClipboardContent();
+  if (!content) return;
+
+  size_t length = strlen(content);
+
+  if (length < TERM_CLIPBOARD_MESSAGE_SIZE) {
+    sendTerminalMessage(TERM_MSG_CLIPBOARD_TO_HOST, content, length);
+  } else {
+    logMessage(LOG_CATEGORY(SCREEN_DRIVER),
+               "BRLTTY clipboard too large to bridge: %"PRIsize, length);
+  }
+
+  free(content);
+}
+
 static void
 enableMessages (key_t key) {
   haveTerminalMessageQueue = getMessageQueue(&terminalMessageQueue, key);
@@ -132,6 +163,12 @@ enableMessages (key_t key) {
       terminalMessageQueue, TERM_MSG_EMULATOR_EXITING,
       0, messageHandler_emulatorExiting, NULL
     );
+
+    if (!clipboardReportListener) {
+      clipboardReportListener = registerReportListener(
+        REPORT_API_PARAMETER_UPDATED, clipboardParameterListener, NULL
+      );
+    }
   }
 }
 
@@ -211,6 +248,11 @@ destruct_TerminalEmulatorScreen (void) {
   if (cachedSegment) {
     free(cachedSegment);
     cachedSegment = NULL;
+  }
+
+  if (clipboardReportListener) {
+    unregisterReportListener(clipboardReportListener);
+    clipboardReportListener = NULL;
   }
 
   haveScreenSegmentKey = 0;

--- a/Drivers/Screen/TerminalEmulator/screen.c
+++ b/Drivers/Screen/TerminalEmulator/screen.c
@@ -88,6 +88,13 @@ static const char *problemText = NULL;
 static ScreenSegmentHeader *screenSegment = NULL;
 static ScreenSegmentHeader *cachedSegment = NULL;
 
+/* The emulator recreates its shared-memory segment (under the same key) when
+ * the terminal is resized, so the identifier we attached to becomes stale. We
+ * remember the key and identifier to detect this and re-attach. */
+static key_t screenSegmentKey = 0;
+static int haveScreenSegmentKey = 0;
+static int screenSegmentIdentifier = -1;
+
 static int haveTerminalMessageQueue = 0;
 static int terminalMessageQueue;
 static int haveSegmentUpdatedHandler = 0;
@@ -133,7 +140,14 @@ accessSegmentForPath (const char *path) {
   key_t key;
 
   if (makeTerminalKey(&key, path)) {
-    if ((screenSegment = getScreenSegmentForKey(key))) {
+    int identifier;
+
+    if (getScreenSegment(&identifier, key) &&
+        (screenSegment = attachScreenSegment(identifier))) {
+      screenSegmentKey = key;
+      haveScreenSegmentKey = 1;
+      screenSegmentIdentifier = identifier;
+
       problemText = gettext("no screen cache");
       enableMessages(key);
       return 1;
@@ -143,6 +157,31 @@ accessSegmentForPath (const char *path) {
   }
 
   return 0;
+}
+
+/* When the emulator resizes, it publishes a new segment under the same key.
+ * Detect the changed identifier and re-attach so we read the new size. */
+static void
+reattachIfSegmentChanged (void) {
+  if (!haveScreenSegmentKey) return;
+
+  int identifier;
+  if (!getScreenSegment(&identifier, screenSegmentKey)) return;
+  if (identifier == screenSegmentIdentifier) return;
+
+  ScreenSegmentHeader *fresh = attachScreenSegment(identifier);
+  if (!fresh) return;
+
+  logMessage(LOG_CATEGORY(SCREEN_DRIVER), "re-attaching to resized screen segment");
+
+  if (screenSegment) detachScreenSegment(screenSegment);
+  screenSegment = fresh;
+  screenSegmentIdentifier = identifier;
+
+  if (cachedSegment) {
+    free(cachedSegment);
+    cachedSegment = NULL;
+  }
 }
 
 static void
@@ -173,6 +212,9 @@ destruct_TerminalEmulatorScreen (void) {
     free(cachedSegment);
     cachedSegment = NULL;
   }
+
+  haveScreenSegmentKey = 0;
+  screenSegmentIdentifier = -1;
 }
 
 static void
@@ -410,6 +452,7 @@ poll_TerminalEmulatorScreen (void) {
 
 static int
 refresh_TerminalEmulatorScreen (void) {
+  reattachIfSegmentChanged();
   if (!screenSegment) return 0;
   size_t size = screenSegment->segmentSize;
 

--- a/Drivers/Screen/TerminalEmulator/screen.c
+++ b/Drivers/Screen/TerminalEmulator/screen.c
@@ -447,7 +447,13 @@ construct_TerminalEmulatorScreen (void) {
 
 static int
 poll_TerminalEmulatorScreen (void) {
-  return !haveSegmentUpdatedHandler;
+  /* The segment-updated message is a best-effort, non-blocking notification
+   * (see ptyRefreshScreen()/sendTerminalMessage() in pty_screen.c) - the small
+   * SysV queue can fill and silently drop it. Always poll as a fallback so a
+   * dropped notification costs at most one poll interval instead of leaving
+   * the braille display stuck until some unrelated event (e.g. a key press)
+   * happens to trigger a refresh. */
+  return 1;
 }
 
 static int

--- a/Headers/get_curses.h
+++ b/Headers/get_curses.h
@@ -29,6 +29,24 @@
 
 #elif defined(HAVE_PKG_NCURSES)
 #define GOT_CURSES
+
+/* Some systems (notably macOS) ship an ncurses that is built with
+ * wide-character support but merged into the plain library rather than a
+ * separate ncursesw, so configure selects the NCURSES package. Request the
+ * X/Open extended (wide) interfaces before including the header so that
+ * cchar_t, add_wch(), in_wch(), setcchar() and friends become available.
+ * Define BRLTTY_NO_CURSES_WCH to opt out.
+ */
+#if defined(__APPLE__) && !defined(BRLTTY_NO_CURSES_WCH)
+#ifndef _XOPEN_SOURCE_EXTENDED
+#define _XOPEN_SOURCE_EXTENDED 1
+#endif /* _XOPEN_SOURCE_EXTENDED */
+#ifndef NCURSES_WIDECHAR
+#define NCURSES_WIDECHAR 1
+#endif /* NCURSES_WIDECHAR */
+#define GOT_CURSES_WCH
+#endif /* wide ncurses */
+
 #include <ncurses.h>
 
 #elif defined(HAVE_PKG_NCURSESW)

--- a/Headers/pty_clipboard.h
+++ b/Headers/pty_clipboard.h
@@ -1,0 +1,39 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+#ifndef BRLTTY_INCLUDED_PTY_CLIPBOARD
+#define BRLTTY_INCLUDED_PTY_CLIPBOARD
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* Put UTF-8 text onto the host's system clipboard (used to honor OSC 52 from a
+ * program running inside the terminal). Returns non-zero on success. Does
+ * nothing and returns zero where no integration is available. This must not
+ * fork: brltty-pty's single select() loop and its CoreFoundation linkage make
+ * spawning a subprocess (e.g. pbcopy) from the I/O path unsafe on macOS. */
+extern int ptySetSystemClipboard (const char *bytes, size_t length);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* BRLTTY_INCLUDED_PTY_CLIPBOARD */

--- a/Headers/pty_clipboard.h
+++ b/Headers/pty_clipboard.h
@@ -25,12 +25,24 @@
 extern "C" {
 #endif /* __cplusplus */
 
-/* Put UTF-8 text onto the host's system clipboard (used to honor OSC 52 from a
- * program running inside the terminal). Returns non-zero on success. Does
- * nothing and returns zero where no integration is available. This must not
- * fork: brltty-pty's single select() loop and its CoreFoundation linkage make
- * spawning a subprocess (e.g. pbcopy) from the I/O path unsafe on macOS. */
-extern int ptySetSystemClipboard (const char *bytes, size_t length);
+/* Resolve, once, how the terminal's clipboard is published to the host. Two
+ * modes:
+ *   - passthrough: re-emit OSC 52 to the outer terminal, which owns the host
+ *     clipboard (cross-platform; the same thing tmux's "set-clipboard on" does).
+ *   - native: write the host clipboard directly (macOS NSPasteboard).
+ * The default is auto: passthrough, except on terminals known to ignore OSC 52
+ * (macOS Terminal.app), where it falls back to native so copy still works. The
+ * BRLTTY_PTY_CLIPBOARD_MODE environment variable (auto|passthrough|native)
+ * overrides the detection. Safe to call more than once; resolved lazily on first
+ * publish if never called. */
+extern void ptyConfigureClipboard (void);
+
+/* Publish UTF-8 text as the terminal's clipboard, honoring the configured mode
+ * (used for OSC 52 from a program inside the terminal, and for BRLTTY's own
+ * clipboard). Returns non-zero on success. Must not fork: brltty-pty's single
+ * select() loop and its CoreFoundation linkage make spawning a subprocess (e.g.
+ * pbcopy) from the I/O path unsafe on macOS. */
+extern int ptyPublishClipboard (const char *bytes, size_t length);
 
 #ifdef __cplusplus
 }

--- a/Headers/pty_screen.h
+++ b/Headers/pty_screen.h
@@ -38,6 +38,9 @@ extern void ptySetCursorColumn (unsigned int column);
 extern void ptySaveCursorPosition (void);
 extern void ptyRestoreCursorPosition (void);
 
+extern void ptyEnterAlternateScreen (void);
+extern void ptyExitAlternateScreen (void);
+
 extern void ptySetScrollRegion (unsigned int top, unsigned int bottom);
 extern int ptyAmWithinScrollRegion (void);
 extern void ptyScrollDown (unsigned int count);
@@ -61,7 +64,6 @@ extern void ptyInsertCharacters (unsigned int count);
 extern void ptyDeleteCharacters (unsigned int count);
 extern void ptyAddCharacter (wchar_t character);
 
-extern void ptySetCursorVisibility (unsigned int visibility);
 extern void ptySetAttributes (attr_t attributes);
 extern void ptyAddAttributes (attr_t attributes);
 extern void ptyRemoveAttributes (attr_t attributes);

--- a/Headers/pty_screen.h
+++ b/Headers/pty_screen.h
@@ -59,7 +59,7 @@ extern void ptyDeleteLines (unsigned int count);
 
 extern void ptyInsertCharacters (unsigned int count);
 extern void ptyDeleteCharacters (unsigned int count);
-extern void ptyAddCharacter (unsigned char character);
+extern void ptyAddCharacter (wchar_t character);
 
 extern void ptySetCursorVisibility (unsigned int visibility);
 extern void ptySetAttributes (attr_t attributes);
@@ -70,7 +70,12 @@ extern void ptySetBackgroundColor (int color);
 
 extern void ptyClearToEndOfLine (void);
 extern void ptyClearToBeginningOfLine (void);
+extern void ptyClearLine (void);
 extern void ptyClearToEndOfDisplay (void);
+extern void ptyClearToBeginningOfDisplay (void);
+extern void ptyClearDisplay (void);
+extern void ptyEraseCharacters (unsigned int count);
+extern void ptyGetCursorPosition (unsigned int *row, unsigned int *column);
 
 extern void ptySetScreenLogLevel (unsigned char level);
 

--- a/Headers/scr_emulator.h
+++ b/Headers/scr_emulator.h
@@ -50,6 +50,20 @@ extern int destroyScreenSegment (int identifier);
 extern int createMessageQueue (int *queue, key_t key);
 extern int destroyMessageQueue (int queue);
 
+/* SysV IPC objects (message queues, shared-memory segments) have no "die with
+ * owning process" semantics and macOS's system-wide limits on them are tiny
+ * (tens of messages/queues total). A terminal emulator killed uncleanly (a
+ * crash, a force-quit, SIGKILL) leaks its queue and segment, and enough leaks
+ * exhaust the whole system - after which unrelated, perfectly healthy
+ * processes start blocking forever on IPC calls that have nothing to do with
+ * the leaked ones. Since macOS has no portable way to enumerate all SysV IDs
+ * on the system, each emulator instead registers what it created in a small
+ * file-based registry and reaps entries left behind by dead PIDs at the start
+ * of every new instance. */
+extern void reapStaleTerminalResources (void);
+extern void registerTerminalResources (int screenSegmentIdentifier, int messageQueueIdentifier);
+extern void unregisterTerminalResources (void);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/Headers/scr_terminal.h
+++ b/Headers/scr_terminal.h
@@ -31,7 +31,16 @@ typedef enum {
   TERM_MSG_INPUT_TEXT       = 't', // driver->emulator - UTF-8
   TERM_MSG_SEGMENT_UPDATED  = 'u', // emulator->driver - no content
   TERM_MSG_EMULATOR_EXITING = 'x', // emulator->driver - no content
+
+  // BRLTTY clipboard -> host (system) clipboard bridging. The driver lives in
+  // the daemon (so it owns BRLTTY's clipboard); the emulator runs in the GUI
+  // session (so it can reach the system clipboard). Content is UTF-8.
+  TERM_MSG_CLIPBOARD_TO_HOST   = 'C', // driver->emulator - BRLTTY clipboard text
 } TerminalMessageType;
+
+// The largest clipboard payload exchanged over the message queue. macOS caps a
+// SysV message queue at ~2KB (msgmnb), so larger content is not bridged.
+#define TERM_CLIPBOARD_MESSAGE_SIZE 0X800
 
 extern int getMessageQueue (int *queue, key_t key);
 

--- a/Headers/utf8.h
+++ b/Headers/utf8.h
@@ -37,6 +37,37 @@ extern int convertUtf8ToCodepoint (uint32_t *codepoint, const char **utf8, size_
 extern size_t convertWcharToUtf8 (wchar_t wc, Utf8Buffer utf8);
 extern wint_t convertUtf8ToWchar (const char **utf8, size_t *utfs);
 
+/* Incremental (streaming) UTF-8 decoder. Bytes are supplied one at a time,
+ * which suits a terminal emulator that consumes its input a byte at a time.
+ * Zero-initialize the decoder before first use (and after each completed or
+ * invalid character it is ready for the next one).
+ */
+typedef struct {
+  uint32_t codepoint; /* accumulated value so far */
+  uint32_t minimum; /* smallest value legal for this length (overlong guard) */
+  unsigned char pending; /* continuation bytes still expected */
+} Utf8StreamDecoder;
+
+typedef enum {
+  UTF8_DECODE_PENDING, /* byte consumed; more bytes are needed */
+  UTF8_DECODE_DONE,    /* *character is a complete code point */
+  UTF8_DECODE_INVALID  /* malformed input; *character is U+FFFD */
+} Utf8DecodeResult;
+
+/* Feed one byte to the decoder.
+ *
+ * On UTF8_DECODE_DONE the decoded code point is stored in *character.
+ *
+ * On UTF8_DECODE_INVALID the replacement character (U+FFFD) is stored in
+ * *character and, if the offending byte may itself start a new character,
+ * *reprocess is set non-zero so the caller can feed that same byte again.
+ * *reprocess is always written (0 unless a restart is required).
+ */
+extern Utf8DecodeResult putUtf8StreamByte (
+  Utf8StreamDecoder *decoder, unsigned char byte,
+  wchar_t *character, int *reprocess
+);
+
 extern void convertUtf8ToWchars (const char **utf8, wchar_t **characters, size_t count);
 
 extern size_t makeUtf8FromWchars (const wchar_t *characters, unsigned int count, char *buffer, size_t size);

--- a/Programs/Makefile.in
+++ b/Programs/Makefile.in
@@ -35,7 +35,7 @@ all-tools: all-brltty-cldr all-brltty-lsinc
 all-brltty-cldr: brltty-cldr$X
 all-brltty-lsinc: brltty-lsinc$X
 
-everything: all all-brltest all-spktest all-scrtest all-cmdtest all-colortest all-crctest all-matchtest all-msgtest
+everything: all all-brltest all-spktest all-scrtest all-cmdtest all-colortest all-crctest all-matchtest all-msgtest all-utf8test all-ptytest all-ptyinput all-ptyresize
 all-brltest: brltest$X | $(BRAILLE_DRIVERS)
 all-spktest: spktest$X | $(SPEECH_DRIVERS)
 all-scrtest: scrtest$X | $(SCREEN_DRIVERS)
@@ -44,6 +44,17 @@ all-colortest: colortest$X
 all-crctest: crctest$X
 all-matchtest: matchtest$X
 all-msgtest: msgtest$X
+all-utf8test: utf8test$X
+all-ptytest: ptytest$X
+all-ptyinput: ptyinput$X
+all-ptyresize: ptyresize$X
+
+# Build and run the brltty-pty test suite.
+tests: utf8test$X ptytest$X ptyinput$X ptyresize$X
+	./utf8test$X
+	./ptytest$X
+	./ptyinput$X
+	./ptyresize$X
 
 all-api: $(ALL_XBRLAPI) all-brltty-clip all-apitest brlapi_brldefs.auto.h
 all-xbrlapi: xbrlapi$X
@@ -405,6 +416,58 @@ crc_generate.$O:
 
 crc_verify.$O:
 	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/crc_verify.c
+
+###############################################################################
+
+UTF8TEST_OBJECTS = utf8test.$O $(PROGRAM_OBJECTS)
+
+utf8test$X: $(UTF8TEST_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(UTF8TEST_OBJECTS) $(LDLIBS)
+
+utf8test.$O:
+	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/utf8test.c
+
+###############################################################################
+
+PTYTEST_OBJECTS = ptytest.$O $(PROGRAM_OBJECTS) $(TERMINAL_EMULATOR_OBJECTS)
+
+ptytest$X: $(PTYTEST_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(PTYTEST_OBJECTS) $(LDLIBS)
+
+ptytest.$O:
+	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptytest.c
+
+###############################################################################
+
+PTYINPUT_OBJECTS = ptyinput.$O $(PROGRAM_OBJECTS)
+
+ptyinput$X: $(PTYINPUT_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(PTYINPUT_OBJECTS) $(LDLIBS)
+
+ptyinput.$O: $(SRC_DIR)/ptyinput.c
+	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptyinput.c
+
+###############################################################################
+
+PTYRESIZE_OBJECTS = ptyresize.$O $(PROGRAM_OBJECTS) $(TERMINAL_EMULATOR_OBJECTS)
+
+ptyresize$X: $(PTYRESIZE_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(PTYRESIZE_OBJECTS) $(LDLIBS)
+
+ptyresize.$O: $(SRC_DIR)/ptyresize.c
+	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptyresize.c
+
+###############################################################################
+
+# Diagnostic helper (not part of the automated suite): render a byte stream
+# through brltty-pty and print the resulting screen grid. See ptydump.c.
+PTYDUMP_OBJECTS = ptydump.$O $(PROGRAM_OBJECTS) $(TERMINAL_EMULATOR_OBJECTS)
+
+ptydump$X: $(PTYDUMP_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(PTYDUMP_OBJECTS) $(LDLIBS)
+
+ptydump.$O:
+	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptydump.c
 
 ###############################################################################
 
@@ -1035,13 +1098,18 @@ scr_emulator.$O:
 msg_queue.$O:
 	$(CC) $(CFLAGS) -c $(SRC_DIR)/msg_queue.c
 
-BRLTTY_PTY_OBJECTS = brltty-pty.$O $(PROGRAM_OBJECTS) pty_object.$O pty_terminal.$O pty_screen.$O color.$O $(TERMINAL_EMULATOR_OBJECTS)
+BRLTTY_PTY_OBJECTS = brltty-pty.$O $(PROGRAM_OBJECTS) pty_object.$O pty_terminal.$O pty_screen.$O pty_clipboard.$O color.$O $(TERMINAL_EMULATOR_OBJECTS)
 
 brltty-pty$X: $(BRLTTY_PTY_OBJECTS)
 	$(CC) $(LDFLAGS) -o $@ $(BRLTTY_PTY_OBJECTS) $(CURSES_LIBS) $(LDLIBS)
 
 brltty-pty.$O:
 	$(CC) $(CFLAGS) -c $(SRC_DIR)/brltty-pty.c
+
+# Compiled with SYSTEM_INCLUDES so it builds as Objective-C on macOS (for the
+# native NSPasteboard clipboard) and as plain C (a stub) elsewhere.
+pty_clipboard.$O: $(SRC_DIR)/pty_clipboard.c
+	$(CC) $(LIBCFLAGS) $(SYSTEM_INCLUDES) -c $(SRC_DIR)/pty_clipboard.c
 
 pty_object.$O:
 	$(CC) $(CFLAGS) -c $(SRC_DIR)/pty_object.c

--- a/Programs/Makefile.in
+++ b/Programs/Makefile.in
@@ -35,7 +35,7 @@ all-tools: all-brltty-cldr all-brltty-lsinc
 all-brltty-cldr: brltty-cldr$X
 all-brltty-lsinc: brltty-lsinc$X
 
-everything: all all-brltest all-spktest all-scrtest all-cmdtest all-colortest all-crctest all-matchtest all-msgtest all-utf8test all-ptytest all-ptyinput all-ptyresize
+everything: all all-brltest all-spktest all-scrtest all-cmdtest all-colortest all-crctest all-matchtest all-msgtest all-utf8test all-ptytest all-ptyinput all-ptyresize all-ptyclip
 all-brltest: brltest$X | $(BRAILLE_DRIVERS)
 all-spktest: spktest$X | $(SPEECH_DRIVERS)
 all-scrtest: scrtest$X | $(SCREEN_DRIVERS)
@@ -48,13 +48,15 @@ all-utf8test: utf8test$X
 all-ptytest: ptytest$X
 all-ptyinput: ptyinput$X
 all-ptyresize: ptyresize$X
+all-ptyclip: ptyclip$X
 
 # Build and run the brltty-pty test suite.
-tests: utf8test$X ptytest$X ptyinput$X ptyresize$X
+tests: utf8test$X ptytest$X ptyinput$X ptyresize$X ptyclip$X
 	./utf8test$X
 	./ptytest$X
 	./ptyinput$X
 	./ptyresize$X
+	./ptyclip$X
 
 all-api: $(ALL_XBRLAPI) all-brltty-clip all-apitest brlapi_brldefs.auto.h
 all-xbrlapi: xbrlapi$X
@@ -456,6 +458,16 @@ ptyresize$X: $(PTYRESIZE_OBJECTS)
 
 ptyresize.$O: $(SRC_DIR)/ptyresize.c
 	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptyresize.c
+
+###############################################################################
+
+PTYCLIP_OBJECTS = ptyclip.$O $(PROGRAM_OBJECTS) $(TERMINAL_EMULATOR_OBJECTS)
+
+ptyclip$X: $(PTYCLIP_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(PTYCLIP_OBJECTS) $(LDLIBS)
+
+ptyclip.$O: $(SRC_DIR)/ptyclip.c
+	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptyclip.c
 
 ###############################################################################
 

--- a/Programs/Makefile.in
+++ b/Programs/Makefile.in
@@ -35,7 +35,7 @@ all-tools: all-brltty-cldr all-brltty-lsinc
 all-brltty-cldr: brltty-cldr$X
 all-brltty-lsinc: brltty-lsinc$X
 
-everything: all all-brltest all-spktest all-scrtest all-cmdtest all-colortest all-crctest all-matchtest all-msgtest all-utf8test all-ptytest all-ptyinput all-ptyresize all-ptyclip
+everything: all all-brltest all-spktest all-scrtest all-cmdtest all-colortest all-crctest all-matchtest all-msgtest all-utf8test all-ptytest all-ptyinput all-ptyresize all-ptyclip all-ptypass
 all-brltest: brltest$X | $(BRAILLE_DRIVERS)
 all-spktest: spktest$X | $(SPEECH_DRIVERS)
 all-scrtest: scrtest$X | $(SCREEN_DRIVERS)
@@ -49,14 +49,16 @@ all-ptytest: ptytest$X
 all-ptyinput: ptyinput$X
 all-ptyresize: ptyresize$X
 all-ptyclip: ptyclip$X
+all-ptypass: ptypass$X
 
 # Build and run the brltty-pty test suite.
-tests: utf8test$X ptytest$X ptyinput$X ptyresize$X ptyclip$X
+tests: utf8test$X ptytest$X ptyinput$X ptyresize$X ptyclip$X ptypass$X
 	./utf8test$X
 	./ptytest$X
 	./ptyinput$X
 	./ptyresize$X
 	./ptyclip$X
+	./ptypass$X
 
 all-api: $(ALL_XBRLAPI) all-brltty-clip all-apitest brlapi_brldefs.auto.h
 all-xbrlapi: xbrlapi$X
@@ -468,6 +470,16 @@ ptyclip$X: $(PTYCLIP_OBJECTS)
 
 ptyclip.$O: $(SRC_DIR)/ptyclip.c
 	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptyclip.c
+
+###############################################################################
+
+PTYPASS_OBJECTS = ptypass.$O $(PROGRAM_OBJECTS) $(TERMINAL_EMULATOR_OBJECTS)
+
+ptypass$X: $(PTYPASS_OBJECTS)
+	$(CC) $(LDFLAGS) -o $@ $(PTYPASS_OBJECTS) $(LDLIBS)
+
+ptypass.$O: $(SRC_DIR)/ptypass.c
+	$(CC) $(LIBCFLAGS) -c $(SRC_DIR)/ptypass.c
 
 ###############################################################################
 

--- a/Programs/Makefile.in
+++ b/Programs/Makefile.in
@@ -1350,6 +1350,7 @@ install-messages:
 
 install-manpages: install-man1-directory
 	$(INSTALL_DATA) $(BLD_TOP)$(DOC_DIR)/brltty.1 $(INSTALL_MAN1_DIRECTORY)
+	$(INSTALL_DATA) $(BLD_TOP)$(DOC_DIR)/brltty-pty.1 $(INSTALL_MAN1_DIRECTORY)
 
 PKGCONFIG_FILE_NAME = brltty.pc
 PKGCONFIG_FILE_PATH = $(INSTALL_PKGCONFIG_DIRECTORY)/$(PKGCONFIG_FILE_NAME)
@@ -1429,6 +1430,7 @@ uninstall-messages:
 
 uninstall-manpages:
 	-rm -f $(INSTALL_ROOT)$(MANPAGE_DIRECTORY)/man1/brltty.1
+	-rm -f $(INSTALL_ROOT)$(MANPAGE_DIRECTORY)/man1/brltty-pty.1
 	-rm -f $(INSTALL_ROOT)$(MANPAGE_DIRECTORY)/man1/xbrlapi.1
 	-rm -f $(INSTALL_MAN3_DIRECTORY)/brlapi_*.3
 

--- a/Programs/brltty-pty.c
+++ b/Programs/brltty-pty.c
@@ -18,7 +18,6 @@
 
 /* not done yet:
  * parent: terminal type list
- * screen: resize
  */
 
 #include "prologue.h"
@@ -41,6 +40,7 @@
 #include "async_wait.h"
 #include "async_io.h"
 #include "async_signal.h"
+#include "async_alarm.h"
 
 static int opt_driverDirectives;
 static int opt_showPath;
@@ -296,8 +296,60 @@ static unsigned char parentIsQuitting;
 static unsigned char childHasTerminated;
 static unsigned char slaveHasBeenClosed;
 
+/* Dragging a window emits a storm of SIGWINCH signals; recreating the screen
+ * segment for each one would be wasteful. Coalesce them: each signal just sets
+ * this flag (the only thing a signal handler may safely do), and the async loop
+ * (re)arms a short settle alarm so the resize happens once, after it settles. */
+static volatile sig_atomic_t windowSizeChanged = 0;
+#define WINDOW_RESIZE_SETTLE_TIME 150
+
+static AsyncHandle windowResizeAlarm = NULL;
+
+static void
+applyWindowSize (void) {
+  size_t width, height;
+
+  if (getConsoleSize(&width, &height)) {
+    setWindowSize(ptyGetMaster(ptyObject), width, height);
+    ptyResizeTerminal(height, width);
+  }
+}
+
+ASYNC_ALARM_CALLBACK(windowResizeAlarmCallback) {
+  asyncDiscardHandle(windowResizeAlarm);
+  windowResizeAlarm = NULL;
+  applyWindowSize();
+}
+
+/* Run in the async loop (NOT signal context): arm/reset the settle alarm if a
+ * SIGWINCH was seen. Arming the alarm allocates, so it must not run in the
+ * signal handler itself. */
+static void
+serviceWindowSizeChange (void) {
+  if (!windowSizeChanged) return;
+  windowSizeChanged = 0;
+
+  if (windowResizeAlarm) {
+    asyncResetAlarmIn(windowResizeAlarm, WINDOW_RESIZE_SETTLE_TIME);
+  } else {
+    asyncNewRelativeAlarm(&windowResizeAlarm, WINDOW_RESIZE_SETTLE_TIME,
+                          windowResizeAlarmCallback, NULL);
+  }
+}
+
+static void
+cancelWindowResizeAlarm (void) {
+  if (windowResizeAlarm) {
+    asyncCancelRequest(windowResizeAlarm);
+    windowResizeAlarm = NULL;
+  }
+}
+
 static
 ASYNC_CONDITION_TESTER(parentTerminationTester) {
+  /* The SIGWINCH that woke the async wait is serviced here, in safe context. */
+  serviceWindowSizeChange();
+
   if (parentIsQuitting) return 1;
 #ifdef __APPLE__
   /* On macOS the PTY slave is not closed by the kernel when the child exits,
@@ -314,12 +366,7 @@ parentQuitMonitor (int signalNumber) {
 
 static void
 windowSizeMonitor (int signalNumber) {
-  size_t width, height;
-
-  if (getConsoleSize(&width, &height)) {
-    setWindowSize(ptyGetMaster(ptyObject), width, height);
-    ptyResizeTerminal(height, width);
-  }
+  windowSizeChanged = 1;
 }
 
 static void
@@ -417,6 +464,7 @@ runParent (pid_t child) {
           asyncAwaitCondition(INT_MAX, parentTerminationTester, NULL);
           if (!parentIsQuitting) exitStatus = reapExitStatus(child);
 
+          cancelWindowResizeAlarm();
           ptyEndTerminal();
         }
       }

--- a/Programs/brltty-pty.c
+++ b/Programs/brltty-pty.c
@@ -34,6 +34,7 @@
 #include "cmdline.h"
 #include "pty_object.h"
 #include "pty_terminal.h"
+#include "pty_clipboard.h"
 #include "parse.h"
 #include "file.h"
 #include "async_handle.h"
@@ -488,6 +489,10 @@ main (int argc, char *argv[]) {
   ptySetLogTerminalOutput(opt_logOutput);
   ptySetLogTerminalSequences(opt_logSequences);
   ptySetLogUnexpectedTerminalIO(opt_logUnexpected);
+
+  /* Decide how a copy (OSC 52 from an inner program, or BRLTTY's clipboard) is
+   * published to the host, based on the outer terminal. See pty_clipboard.h. */
+  ptyConfigureClipboard();
 
   /* When invoked by the TerminalEmulator screen driver (which spawns us
    * with --driver-directives so it can read the PTY path back on stderr),

--- a/Programs/brltty-pty.c
+++ b/Programs/brltty-pty.c
@@ -299,6 +299,11 @@ static unsigned char slaveHasBeenClosed;
 static
 ASYNC_CONDITION_TESTER(parentTerminationTester) {
   if (parentIsQuitting) return 1;
+#ifdef __APPLE__
+  /* On macOS the PTY slave is not closed by the kernel when the child exits,
+   * so slaveHasBeenClosed never fires.  Exit as soon as the child terminates. */
+  if (childHasTerminated) return 1;
+#endif /* __APPLE__ */
   return childHasTerminated && slaveHasBeenClosed;
 }
 

--- a/Programs/pty_clipboard.c
+++ b/Programs/pty_clipboard.c
@@ -20,16 +20,26 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
 
+#include "log.h"
 #include "pty_clipboard.h"
 
-/* An optional override: write the clipboard text to this file instead of the
- * platform clipboard. It is fork-free (plain fopen), so it's safe from the I/O
- * loop; it lets non-macOS users wire up their own clipboard (e.g. a fifo read
- * by xclip/wl-copy) and lets the test suite verify OSC 52 without a pasteboard. */
+/* Optional file override: instead of the host clipboard, write to a file. It is
+ * fork-free (plain stdio), so it is safe from the I/O loop. It lets non-macOS
+ * users wire up their own clipboard (e.g. a fifo paired with xclip/wl-copy), and
+ * lets the test suite intercept what would be published without a real terminal
+ * or pasteboard. It takes precedence over the configured mode below. */
+#define CLIPBOARD_WRITE_FILE_VARIABLE "BRLTTY_PTY_CLIPBOARD_FILE"
+
+/* Override for the auto-detected publish mode (auto|passthrough|native). */
+#define CLIPBOARD_MODE_VARIABLE "BRLTTY_PTY_CLIPBOARD_MODE"
+
 static int
 writeClipboardToFile (const char *bytes, size_t length) {
-  const char *path = getenv("BRLTTY_PTY_CLIPBOARD_FILE");
+  const char *path = getenv(CLIPBOARD_WRITE_FILE_VARIABLE);
   if (!(path && *path)) return 0;
 
   FILE *file = fopen(path, "w");
@@ -43,12 +53,8 @@ writeClipboardToFile (const char *bytes, size_t length) {
 #ifdef __APPLE__
 #import <AppKit/AppKit.h>
 
-/* Set the macOS system pasteboard directly (no fork). Safe to call from
- * brltty-pty's I/O loop, unlike spawning pbcopy. */
-int
-ptySetSystemClipboard (const char *bytes, size_t length) {
-  if (writeClipboardToFile(bytes, length)) return 1;
-
+static int
+setNativeClipboard (const char *bytes, size_t length) {
   @autoreleasepool {
     NSString *string = [[NSString alloc] initWithBytes:bytes
                                                 length:length
@@ -61,12 +67,159 @@ ptySetSystemClipboard (const char *bytes, size_t length) {
   }
 }
 
-#else /* __APPLE__ */
+static int nativeClipboardAvailable (void) { return 1; }
 
-int
-ptySetSystemClipboard (const char *bytes, size_t length) {
-  /* No native clipboard on this platform; honor the file override if set. */
-  return writeClipboardToFile(bytes, length);
-}
+#else /* __APPLE__ - no native backend on this platform yet */
+
+static int setNativeClipboard (const char *bytes, size_t length) { return 0; }
+static int nativeClipboardAvailable (void) { return 0; }
 
 #endif /* __APPLE__ */
+
+/* Passthrough: re-emit the clipboard as an OSC 52 sequence to the outer terminal
+ * (our stdout), so that terminal publishes it to the host - exactly what tmux's
+ * "set-clipboard on" does. This is cross-platform and lets the terminal own the
+ * clipboard (and its own security prompts). OSC 52 is an invisible control
+ * string, so writing it between curses screen updates does not disturb the
+ * display. */
+static const char base64Alphabet[] =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static char *
+encodeBase64 (const unsigned char *data, size_t length, size_t *encodedLength) {
+  size_t outLength = ((length + 2) / 3) * 4;
+  char *out = malloc(outLength + 1);
+  if (!out) return NULL;
+
+  size_t in = 0;
+  size_t off = 0;
+
+  while ((length - in) >= 3) {
+    unsigned int triple = (data[in] << 16) | (data[in+1] << 8) | data[in+2];
+    out[off++] = base64Alphabet[(triple >> 18) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 12) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 6) & 0X3F];
+    out[off++] = base64Alphabet[triple & 0X3F];
+    in += 3;
+  }
+
+  size_t remaining = length - in;
+  if (remaining == 1) {
+    unsigned int triple = data[in] << 16;
+    out[off++] = base64Alphabet[(triple >> 18) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 12) & 0X3F];
+    out[off++] = '=';
+    out[off++] = '=';
+  } else if (remaining == 2) {
+    unsigned int triple = (data[in] << 16) | (data[in+1] << 8);
+    out[off++] = base64Alphabet[(triple >> 18) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 12) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 6) & 0X3F];
+    out[off++] = '=';
+  }
+
+  out[off] = 0;
+  if (encodedLength) *encodedLength = off;
+  return out;
+}
+
+static int
+writeAll (int fd, const char *data, size_t length) {
+  size_t total = 0;
+
+  while (total < length) {
+    ssize_t count = write(fd, data + total, length - total);
+
+    if (count < 0) {
+      if (errno == EINTR) continue;
+      return 0;
+    }
+
+    total += count;
+  }
+
+  return 1;
+}
+
+static int
+emitClipboardPassthrough (const char *bytes, size_t length) {
+  size_t encodedLength;
+  char *encoded = encodeBase64((const unsigned char *)bytes, length, &encodedLength);
+  if (!encoded) return 0;
+
+  static const char prefix[] = "\033]52;c;";
+  static const char suffix[] = "\a"; /* BEL string terminator */
+
+  int ok = writeAll(STDOUT_FILENO, prefix, sizeof(prefix) - 1)
+        && writeAll(STDOUT_FILENO, encoded, encodedLength)
+        && writeAll(STDOUT_FILENO, suffix, sizeof(suffix) - 1);
+
+  free(encoded);
+  return ok;
+}
+
+typedef enum {
+  CLIPBOARD_MODE_PASSTHROUGH,
+  CLIPBOARD_MODE_NATIVE,
+} ClipboardMode;
+
+static int clipboardModeResolved = 0;
+static ClipboardMode clipboardMode = CLIPBOARD_MODE_PASSTHROUGH;
+
+/* Over ssh there is no local pasteboard we can usefully write: any native
+ * clipboard we could reach would be the *remote* machine's, not the user's. So
+ * when running remotely the only way to the user's clipboard is to hand an OSC 52
+ * to the terminal at the near end (passthrough). */
+static int
+runningRemotely (void) {
+  return (getenv("SSH_CONNECTION") != NULL) || (getenv("SSH_TTY") != NULL);
+}
+
+static ClipboardMode
+resolveClipboardMode (void) {
+  const char *requested = getenv(CLIPBOARD_MODE_VARIABLE);
+
+  if (requested && *requested) {
+    if (strcmp(requested, "passthrough") == 0) return CLIPBOARD_MODE_PASSTHROUGH;
+    if (strcmp(requested, "native") == 0) return CLIPBOARD_MODE_NATIVE;
+    /* "auto" or anything unrecognized falls through to detection. */
+  }
+
+  /* Locally, writing the pasteboard directly is the most reliable path: it
+   * reaches the user's clipboard regardless of which terminal is in use, and -
+   * unlike OSC 52 - it works even under screen/tmux, which can swallow the
+   * sequence. We only hand the terminal an OSC 52 when we cannot reach a local
+   * pasteboard: over ssh, or where there is no native backend at all. */
+  if (nativeClipboardAvailable() && !runningRemotely()) return CLIPBOARD_MODE_NATIVE;
+  return CLIPBOARD_MODE_PASSTHROUGH;
+}
+
+void
+ptyConfigureClipboard (void) {
+  clipboardMode = resolveClipboardMode();
+  clipboardModeResolved = 1;
+
+  logMessage(LOG_DEBUG, "clipboard publish mode: %s",
+             (clipboardMode == CLIPBOARD_MODE_NATIVE)? "native": "passthrough");
+}
+
+int
+ptyPublishClipboard (const char *bytes, size_t length) {
+  /* The file override always wins: it is the test / DIY-wiring intercept. */
+  if (writeClipboardToFile(bytes, length)) return 1;
+
+  if (!clipboardModeResolved) ptyConfigureClipboard();
+
+  if (clipboardMode == CLIPBOARD_MODE_NATIVE) {
+    if (setNativeClipboard(bytes, length)) return 1;
+
+    /* The pasteboard was unreachable (e.g. no GUI session) or the text wasn't
+     * valid UTF-8. Don't lose the copy: fall back to handing it to the terminal. */
+    logMessage(LOG_WARNING, "native clipboard write failed; using passthrough");
+    return emitClipboardPassthrough(bytes, length);
+  }
+
+  if (emitClipboardPassthrough(bytes, length)) return 1;
+  logMessage(LOG_WARNING, "clipboard passthrough write failed");
+  return 0;
+}

--- a/Programs/pty_clipboard.c
+++ b/Programs/pty_clipboard.c
@@ -1,0 +1,72 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+#include "prologue.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "pty_clipboard.h"
+
+/* An optional override: write the clipboard text to this file instead of the
+ * platform clipboard. It is fork-free (plain fopen), so it's safe from the I/O
+ * loop; it lets non-macOS users wire up their own clipboard (e.g. a fifo read
+ * by xclip/wl-copy) and lets the test suite verify OSC 52 without a pasteboard. */
+static int
+writeClipboardToFile (const char *bytes, size_t length) {
+  const char *path = getenv("BRLTTY_PTY_CLIPBOARD_FILE");
+  if (!(path && *path)) return 0;
+
+  FILE *file = fopen(path, "w");
+  if (!file) return 0;
+
+  fwrite(bytes, 1, length, file);
+  fclose(file);
+  return 1;
+}
+
+#ifdef __APPLE__
+#import <AppKit/AppKit.h>
+
+/* Set the macOS system pasteboard directly (no fork). Safe to call from
+ * brltty-pty's I/O loop, unlike spawning pbcopy. */
+int
+ptySetSystemClipboard (const char *bytes, size_t length) {
+  if (writeClipboardToFile(bytes, length)) return 1;
+
+  @autoreleasepool {
+    NSString *string = [[NSString alloc] initWithBytes:bytes
+                                                length:length
+                                              encoding:NSUTF8StringEncoding];
+    if (!string) return 0;
+
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    [pasteboard clearContents];
+    return [pasteboard setString:string forType:NSPasteboardTypeString]? 1: 0;
+  }
+}
+
+#else /* __APPLE__ */
+
+int
+ptySetSystemClipboard (const char *bytes, size_t length) {
+  /* No native clipboard on this platform; honor the file override if set. */
+  return writeClipboardToFile(bytes, length);
+}
+
+#endif /* __APPLE__ */

--- a/Programs/pty_object.c
+++ b/Programs/pty_object.c
@@ -18,13 +18,14 @@
 
 #include "prologue.h"
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
 
 #include "log.h"
 #include "pty_object.h"
 #include "scr_types.h"
-#include "get_term.h"
 
 struct PtyObjectStruct {
   char *path;
@@ -112,173 +113,133 @@ ptyWriteInputData (PtyObject *pty, const void *data, size_t length) {
   return 0;
 }
 
+/* All of the ScreenKey modifier flags, so the base key can be isolated without
+ * truncating astral-plane code points (which the SCR_KEY_CHAR_MASK would). */
+#define PTY_KEY_MODIFIER_MASK ( \
+  SCR_KEY_SHIFT | SCR_KEY_UPPER | SCR_KEY_CONTROL | \
+  SCR_KEY_ALT_LEFT | SCR_KEY_ALT_RIGHT | SCR_KEY_GUI | SCR_KEY_CAPSLOCK \
+)
+
+/* Encode a key for the child and write it to the pty.
+ *
+ * The byte sequences are taken from tmux's input-keys.c so that they match the
+ * terminfo we advertise to the child (the screen/tmux family). We deliberately
+ * do NOT consult the host's terminfo: that describes the *outer* terminal and
+ * may encode a key differently (famously Home as "ESC O H" rather than the
+ * "ESC [ 1 ~" a screen/tmux program expects), which would make the child
+ * mis-read the key - e.g. vim treating the "O" as "open line and insert".
+ *
+ * Modifiers carried in the ScreenKey (Shift/Alt/Control) are emitted using the
+ * standard xterm scheme: a parameter of 1 + (shift?1) + (alt?2) + (ctrl?4),
+ * which every screen/tmux-aware program understands. kxMode selects the
+ * application-cursor-keys form (DECCKM) for the arrow keys.
+ */
 int
 ptyWriteInputCharacter (PtyObject *pty, wchar_t character, int kxMode) {
-  if (!isSpecialKey(character)) {
-    char buffer[MB_CUR_MAX];
-    int count = wctomb(buffer, character);
+  unsigned int modifiers = 0;
+  if (character & SCR_KEY_SHIFT) modifiers |= 1;
+  if (character & (SCR_KEY_ALT_LEFT | SCR_KEY_ALT_RIGHT)) modifiers |= 2;
+  if (character & SCR_KEY_CONTROL) modifiers |= 4;
+
+  ScreenKey key = character & ~PTY_KEY_MODIFIER_MASK;
+  unsigned int modParam = modifiers? (modifiers + 1): 0;
+
+  if (!isSpecialKey(key)) {
+    wchar_t wc = key;
+
+    /* Control folds a typed character down to its C0 control code. */
+    if (modifiers & 4) {
+      if ((wc >= 'a') && (wc <= 'z')) wc = wc - 'a' + 1;
+      else if ((wc >= 'A') && (wc <= 'Z')) wc = wc - 'A' + 1;
+      else if ((wc >= '@') && (wc <= '_')) wc = wc - '@';
+      else if (wc == ' ') wc = 0;
+      else if (wc == '?') wc = 0X7F;
+    }
+
+    char bytes[1 + MB_CUR_MAX];
+    char *out = bytes;
+    if (modifiers & 2) *out++ = 0X1B;   /* Alt/Meta is an ESC prefix. */
+
+    int count = wctomb(out, wc);
     if (count == -1) return 0;
-    return ptyWriteInputData(pty, buffer, count);
+    return ptyWriteInputData(pty, bytes, (out - bytes) + count);
   }
 
-  const char *capability = NULL;
-  const char *sequence = NULL;
   char buffer[0X20];
+  const char *seq = NULL;
 
-  #define KEY(key, cap) case SCR_KEY_##key: capability = #cap; break;
-  switch (character) {
-      KEY(ENTER       , kent)
-      KEY(BACKSPACE   , kbs)
+  char final = 0;       /* letter-form keys: arrows, Home, End, F1-F4 */
+  int isCursor = 0;     /* arrows additionally honor kxMode (DECCKM)   */
+  int tilde = 0;        /* "ESC [ <n> ~" form keys                     */
 
-      KEY(CURSOR_LEFT , kcub1)
-      KEY(CURSOR_RIGHT, kcuf1)
-      KEY(CURSOR_UP   , kcuu1)
-      KEY(CURSOR_DOWN , kcud1)
+  switch (key) {
+    case SCR_KEY_ENTER:     seq = "\r";   break;
+    case SCR_KEY_TAB:       seq = "\t";   break;
+    case SCR_KEY_BACKSPACE: seq = "\x7F"; break;
+    case SCR_KEY_ESCAPE:    seq = "\x1B"; break;
 
-      KEY(PAGE_UP     , kpp)
-      KEY(PAGE_DOWN   , knp)
-      KEY(HOME        , khome)
-      KEY(END         , kend)
-      KEY(INSERT      , kich1)
-      KEY(DELETE      , kdch1)
+    case SCR_KEY_CURSOR_UP:    final = 'A'; isCursor = 1; break;
+    case SCR_KEY_CURSOR_DOWN:  final = 'B'; isCursor = 1; break;
+    case SCR_KEY_CURSOR_RIGHT: final = 'C'; isCursor = 1; break;
+    case SCR_KEY_CURSOR_LEFT:  final = 'D'; isCursor = 1; break;
 
-      KEY(F1          , kf1)
-      KEY(F2          , kf2)
-      KEY(F3          , kf3)
-      KEY(F4          , kf4)
-      KEY(F5          , kf5)
-      KEY(F6          , kf6)
-      KEY(F7          , kf7)
-      KEY(F8          , kf8)
-      KEY(F9          , kf9)
-      KEY(F10         , kf10)
-      KEY(F11         , kf11)
-      KEY(F12         , kf12)
-      KEY(F13         , kf13)
-      KEY(F14         , kf14)
-      KEY(F15         , kf15)
-      KEY(F16         , kf16)
-      KEY(F17         , kf17)
-      KEY(F18         , kf18)
-      KEY(F19         , kf19)
-      KEY(F20         , kf20)
-      KEY(F21         , kf21)
-      KEY(F22         , kf22)
-      KEY(F23         , kf23)
-      KEY(F24         , kf24)
-      KEY(F25         , kf25)
-      KEY(F26         , kf26)
-      KEY(F27         , kf27)
-      KEY(F28         , kf28)
-      KEY(F29         , kf29)
-      KEY(F30         , kf30)
-      KEY(F31         , kf31)
-      KEY(F32         , kf32)
-      KEY(F33         , kf33)
-      KEY(F34         , kf34)
-      KEY(F35         , kf35)
-      KEY(F36         , kf36)
-      KEY(F37         , kf37)
-      KEY(F38         , kf38)
-      KEY(F39         , kf39)
-      KEY(F40         , kf40)
-      KEY(F41         , kf41)
-      KEY(F42         , kf42)
-      KEY(F43         , kf43)
-      KEY(F44         , kf44)
-      KEY(F45         , kf45)
-      KEY(F46         , kf46)
-      KEY(F47         , kf47)
-      KEY(F48         , kf48)
-      KEY(F49         , kf49)
-      KEY(F50         , kf50)
-      KEY(F51         , kf51)
-      KEY(F52         , kf52)
-      KEY(F53         , kf53)
-      KEY(F54         , kf54)
-      KEY(F55         , kf55)
-      KEY(F56         , kf56)
-      KEY(F57         , kf57)
-      KEY(F58         , kf58)
-      KEY(F59         , kf59)
-      KEY(F60         , kf60)
-      KEY(F61         , kf61)
-      KEY(F62         , kf62)
-      KEY(F63         , kf63)
-  }
-  #undef KEY
+    case SCR_KEY_HOME: final = 'H'; tilde = 1; break;  /* unmodified -> ESC[1~ */
+    case SCR_KEY_END:  final = 'F'; tilde = 4; break;  /* unmodified -> ESC[4~ */
 
-  if (capability) {
-    sequence = tigetstr(capability);
-    intptr_t result = (intptr_t)sequence;
+    case SCR_KEY_INSERT:    tilde = 2; break;
+    case SCR_KEY_DELETE:    tilde = 3; break;
+    case SCR_KEY_PAGE_UP:   tilde = 5; break;
+    case SCR_KEY_PAGE_DOWN: tilde = 6; break;
 
-    switch (result) {
-      case -1:
-        logMessage(LOG_WARNING, "not a terminfo string capability: %s", capability);
-        goto NO_SEQUENCE;
+    case SCR_KEY_F1: final = 'P'; break;
+    case SCR_KEY_F2: final = 'Q'; break;
+    case SCR_KEY_F3: final = 'R'; break;
+    case SCR_KEY_F4: final = 'S'; break;
 
-      case 0:
-        logMessage(LOG_WARNING, "unrecognized terminfo capability: %s", capability);
-        goto NO_SEQUENCE;
+    default: {
+      /* F5..F20 use the numbered "ESC [ <n> ~" form. */
+      static const unsigned char fnTilde[] = {
+        15, 17, 18, 19, 20, 21, 23, 24, 25, 26, 28, 29, 31, 32, 33, 34
+      };
 
-      NO_SEQUENCE:
-        sequence = NULL;
-      default:
-        break;
+      if ((key >= SCR_KEY_F5) && (key <= SCR_KEY_F20)) {
+        tilde = fnTilde[key - SCR_KEY_F5];
+      }
+
+      break;
     }
   }
 
-  if (!sequence) {
-    #define KEY(key, seq) case SCR_KEY_##key: sequence = seq; break;
-    switch (character) {
-      KEY(ENTER       , "\r")
-      KEY(TAB         , "\t")
-      KEY(BACKSPACE   , "\x7F")
-      KEY(ESCAPE      , "\x1B")
+  if (!seq) {
+    if (final && !tilde) {
+      /* arrows and F1-F4 */
+      if (modParam) {
+        snprintf(buffer, sizeof(buffer), "\x1B[1;%u%c", modParam, final);
+      } else if (isCursor) {
+        snprintf(buffer, sizeof(buffer), "\x1B%c%c", (kxMode? 'O': '['), final);
+      } else {
+        snprintf(buffer, sizeof(buffer), "\x1BO%c", final);
+      }
 
-      KEY(CURSOR_UP   , "\x1BOA")
-      KEY(CURSOR_DOWN , "\x1BOB")
-      KEY(CURSOR_RIGHT, "\x1BOC")
-      KEY(CURSOR_LEFT , "\x1BOD")
+      seq = buffer;
+    } else if (tilde) {
+      if (modParam && final) {
+        /* Home/End, when modified, use the letter form (ESC[1;modH|F). */
+        snprintf(buffer, sizeof(buffer), "\x1B[1;%u%c", modParam, final);
+      } else if (modParam) {
+        snprintf(buffer, sizeof(buffer), "\x1B[%d;%u~", tilde, modParam);
+      } else {
+        snprintf(buffer, sizeof(buffer), "\x1B[%d~", tilde);
+      }
 
-      KEY(HOME        , "\x1B[1~")
-      KEY(INSERT      , "\x1B[2~")
-      KEY(DELETE      , "\x1B[3~")
-      KEY(END         , "\x1B[4~")
-      KEY(PAGE_UP     , "\x1B[5~")
-      KEY(PAGE_DOWN   , "\x1B[6~")
-
-      KEY(F1          , "\x1BOP")
-      KEY(F2          , "\x1BOQ")
-      KEY(F3          , "\x1BOR")
-      KEY(F4          , "\x1BOS")
-      KEY(F5          , "\x1B[15~")
-      KEY(F6          , "\x1B[17~")
-      KEY(F7          , "\x1B[18~")
-      KEY(F8          , "\x1B[19~")
-      KEY(F9          , "\x1B[20~")
-      KEY(F10         , "\x1B[21~")
-      KEY(F11         , "\x1B[23~")
-      KEY(F12         , "\x1B[24~")
+      seq = buffer;
     }
-    #undef KEY
   }
 
-  if (sequence) {
-    switch (character) {
-      case SCR_KEY_CURSOR_LEFT:
-      case SCR_KEY_CURSOR_RIGHT:
-      case SCR_KEY_CURSOR_UP:
-      case SCR_KEY_CURSOR_DOWN:
-        strcpy(buffer, sequence);
-        buffer[1] = kxMode? 'O': '[';
-        sequence = buffer;
-        break;
-    }
-
-    if (!ptyWriteInputData(pty, sequence, strlen(sequence))) return 0;
+  if (seq) {
+    if (!ptyWriteInputData(pty, seq, strlen(seq))) return 0;
   } else {
-    logMessage(LOG_WARNING, "unsupported pty screen key: %04X", character);
+    logMessage(LOG_WARNING, "unsupported pty screen key: %04X", (unsigned int)key);
   }
 
   return 1;

--- a/Programs/pty_object.c
+++ b/Programs/pty_object.c
@@ -103,6 +103,12 @@ ptySetLogInput (PtyObject *pty, int yes) {
   pty->logInput = yes;
 }
 
+ASYNC_OUTPUT_CALLBACK(ptyHandleInputWriteResult) {
+  if (parameters->error) {
+    logMessage(LOG_WARNING, "pty write input failed: %s", strerror(parameters->error));
+  }
+}
+
 int
 ptyWriteInputData (PtyObject *pty, const void *data, size_t length) {
   if (pty->logInput) {
@@ -116,8 +122,11 @@ ptyWriteInputData (PtyObject *pty, const void *data, size_t length) {
    * queued message) for as long as the child isn't draining its input -
    * which is exactly when it's busy, e.g. repainting after a jump to the
    * top of the screen. asyncWriteFile() copies the buffer internally, so it
-   * is safe to pass a short-lived/stack buffer here. */
-  if (asyncWriteFile(NULL, pty->master, data, length, NULL, NULL)) return 1;
+   * is safe to pass a short-lived/stack buffer here. The completion callback
+   * only exists to keep logging a failed write visible, since a queued write
+   * fails later (asynchronously) rather than via this function's own return
+   * value. */
+  if (asyncWriteFile(NULL, pty->master, data, length, ptyHandleInputWriteResult, NULL)) return 1;
   logMessage(LOG_WARNING, "pty write input not queued");
   return 0;
 }

--- a/Programs/pty_object.c
+++ b/Programs/pty_object.c
@@ -26,6 +26,7 @@
 #include "log.h"
 #include "pty_object.h"
 #include "scr_types.h"
+#include "async_io.h"
 
 struct PtyObjectStruct {
   char *path;
@@ -108,8 +109,16 @@ ptyWriteInputData (PtyObject *pty, const void *data, size_t length) {
     logBytes(pty->logLevel, "pty input", data, length);
   }
 
-  if (write(pty->master, data, length) != -1) return 1;
-  logSystemError("pty write input");
+  /* Queue the write and let the async I/O loop flush it once the master is
+   * writable, rather than calling write() here directly. This function runs
+   * on the same single thread that also reads the child's output, so a
+   * direct blocking write() would stall all rendering (and every other
+   * queued message) for as long as the child isn't draining its input -
+   * which is exactly when it's busy, e.g. repainting after a jump to the
+   * top of the screen. asyncWriteFile() copies the buffer internally, so it
+   * is safe to pass a short-lived/stack buffer here. */
+  if (asyncWriteFile(NULL, pty->master, data, length, NULL, NULL)) return 1;
+  logMessage(LOG_WARNING, "pty write input not queued");
   return 0;
 }
 

--- a/Programs/pty_screen.c
+++ b/Programs/pty_screen.c
@@ -18,6 +18,8 @@
 
 #include "prologue.h"
 
+#include <wchar.h>
+
 #include "get_term.h"
 #include "log.h"
 #include "pty_screen.h"
@@ -125,6 +127,8 @@ enableMessages (key_t key) {
 
 static int segmentIdentifier = 0;
 static ScreenSegmentHeader *segmentHeader = NULL;
+static key_t segmentKey = 0;
+static int haveSegmentKey = 0;
 
 static int
 destroySegment (void) {
@@ -138,13 +142,12 @@ destroySegment (void) {
 
 static int
 createSegment (const char *path, int driverDirectives) {
-  key_t key;
-
-  if (makeTerminalKey(&key, path)) {
-    segmentHeader = createScreenSegment(&segmentIdentifier, key, LINES, COLS, ENABLE_ROW_ARRAY);
+  if (makeTerminalKey(&segmentKey, path)) {
+    haveSegmentKey = 1;
+    segmentHeader = createScreenSegment(&segmentIdentifier, segmentKey, LINES, COLS, ENABLE_ROW_ARRAY);
 
     if (segmentHeader) {
-      if (driverDirectives) enableMessages(key);
+      if (driverDirectives) enableMessages(segmentKey);
       return 1;
     }
   }
@@ -156,6 +159,21 @@ static void
 storeCursorPosition (void) {
   segmentHeader->cursorRow = getcury(stdscr);
   segmentHeader->cursorColumn = getcurx(stdscr);
+}
+
+/* When a glyph is written into the last column the cursor lingers there with
+ * this flag set, rather than wrapping immediately. The wrap is performed only
+ * when the next glyph arrives. This is the VT "magic margin" / xenl behavior
+ * that screen and tmux (which this emulator impersonates) advertise, and that
+ * full-screen programs such as Claude Code rely on when drawing boxes. */
+static int pendingWrap = 0;
+
+/* Move the curses cursor and mirror the position into the segment, without
+ * disturbing the pending-wrap state (used for internal repositioning). */
+static void
+moveCursor (unsigned int row, unsigned int column) {
+  move(row, column);
+  storeCursorPosition();
 }
 
 static void
@@ -186,7 +204,7 @@ setCharacter (unsigned int row, unsigned int column, const ScreenSegmentCharacte
     unsigned int oldRow = segmentHeader->cursorRow;
     unsigned int oldColumn = segmentHeader->cursorColumn;
     int move = (row != oldRow) || (column != oldColumn);
-    if (move) ptySetCursorPosition(row, column);
+    if (move) moveCursor(row, column);
 
     {
     #ifdef GOT_CURSES_WCH
@@ -204,7 +222,7 @@ setCharacter (unsigned int row, unsigned int column, const ScreenSegmentCharacte
     #endif /* GOT_CURSES_WCH */
     }
 
-    if (move) ptySetCursorPosition(oldRow, oldColumn);
+    if (move) moveCursor(oldRow, oldColumn);
   }
 
   ScreenSegmentCharacter character = {
@@ -278,12 +296,24 @@ ptyBeginScreen (PtyObject *pty, int driverDirectives) {
   haveTerminalMessageQueue = 0;
   haveInputTextHandler = 0;
 
+  /* Make curses size the screen from the real terminal rather than from the
+   * inherited LINES/COLUMNS environment variables. Those variables are often
+   * stale (commonly left at 80x24) and, when honored, would cap the emulated
+   * screen regardless of the actual terminal size. use_tioctl(TRUE) asks
+   * curses to obtain the size from the operating system (TIOCGWINSZ).
+   * use_tioctl is an ncurses extension (6.0+), so guard it. */
+#ifdef NCURSES_VERSION
+  use_env(FALSE);
+  use_tioctl(TRUE);
+#endif /* NCURSES_VERSION */
+
   if (initscr()) {
     intrflush(stdscr, FALSE);
     keypad(stdscr, TRUE);
 
     raw();
     noecho();
+    nonl();
 
     scrollok(stdscr, TRUE);
     idlok(stdscr, TRUE);
@@ -291,6 +321,7 @@ ptyBeginScreen (PtyObject *pty, int driverDirectives) {
 
     scrollRegionTop = getbegy(stdscr);
     scrollRegionBottom = getmaxy(stdscr) - 1;
+    pendingWrap = 0;
 
     savedCursorRow = 0;
     savedCursorColumn = 0;
@@ -342,9 +373,65 @@ ptyEndScreen (void) {
 
 void
 ptyResizeScreen (unsigned int height, unsigned int width) {
+  if ((height == 0) || (width == 0)) return;
+  if ((height == segmentHeader->screenHeight) &&
+      (width == segmentHeader->screenWidth)) {
+    return;
+  }
+
+  /* Resize the curses screen we render through. */
   if (is_term_resized(height, width)) {
     resize_term(height, width);
   }
+
+  /* A System V shared-memory segment cannot be resized in place, so publish a
+   * fresh one at the new size under the same key. The reader notices the new
+   * segment (its identifier changes) and re-attaches; the old mapping stays
+   * valid for anyone still reading it until they detach. */
+  if (haveSegmentKey) {
+    ScreenSegmentHeader *old = segmentHeader;
+
+    /* createScreenSegment removes the prior segment under this key (it calls
+     * getScreenSegment + destroyScreenSegment) before allocating the new one. */
+    ScreenSegmentHeader *fresh = createScreenSegment(
+      &segmentIdentifier, segmentKey, height, width, ENABLE_ROW_ARRAY
+    );
+
+    if (!fresh) {
+      /* Allocation failed: keep the existing (smaller) segment intact rather
+       * than writing the new, larger geometry into it. */
+      logMessage(LOG_WARNING, "screen segment resize failed; keeping old size");
+      return;
+    }
+
+    segmentHeader = fresh;
+    segmentHeader->screenNumber = 1;
+    if (old) detachScreenSegment(old);
+  }
+
+  /* A resize resets the scroll region to the whole screen and cancels any
+   * deferred wrap; clamp the saved cursor to the new bounds. */
+  scrollRegionTop = 0;
+  scrollRegionBottom = height - 1;
+  setscrreg(scrollRegionTop, scrollRegionBottom);
+  pendingWrap = 0;
+
+  if (savedCursorRow >= height) savedCursorRow = height - 1;
+  if (savedCursorColumn >= width) savedCursorColumn = width - 1;
+
+  /* Mirror the (resized) curses screen into the fresh segment so the new
+   * dimensions are immediately populated; the child repaints on its own
+   * SIGWINCH soon after. */
+  storeCursorPosition();
+
+  for (unsigned int row=0; row<height; row+=1) {
+    for (unsigned int column=0; column<width; column+=1) {
+      setCharacter(row, column, NULL);
+    }
+  }
+
+  storeCursorPosition();
+  ptyRefreshScreen();
 }
 
 void
@@ -355,8 +442,9 @@ ptyRefreshScreen (void) {
 
 void
 ptySetCursorPosition (unsigned int row, unsigned int column) {
-  move(row, column);
-  storeCursorPosition();
+  /* Any explicit cursor movement cancels a deferred wrap. */
+  pendingWrap = 0;
+  moveCursor(row, column);
 }
 
 void
@@ -545,15 +633,80 @@ ptyDeleteCharacters (unsigned int count) {
   fillCharacters(segmentHeader->cursorRow, (COLS - count), count);
 }
 
+/* Place a glyph at an explicit position without letting curses scroll at the
+ * bottom-right corner; the caller sets the final cursor position afterwards. */
+static void
+writeGlyph (unsigned int row, unsigned int column, wchar_t character) {
+  scrollok(stdscr, FALSE);
+  move(row, column);
+
+#ifdef GOT_CURSES_WCH
+  {
+    attr_t attributes;
+    short colorPair;
+    attr_get(&attributes, &colorPair, NULL);
+
+    wchar_t string[] = {character, 0};
+    cchar_t wch;
+
+    if (setcchar(&wch, string, attributes, colorPair, NULL) == OK) {
+      add_wch(&wch);
+    } else {
+      addch(character);
+    }
+  }
+#else /* GOT_CURSES_WCH */
+  addch(character);
+#endif /* GOT_CURSES_WCH */
+
+  scrollok(stdscr, TRUE);
+
+  /* Resync the segment cursor with the position curses advanced to, so that
+   * setCharacter() reads back the cells we just wrote rather than the next. */
+  storeCursorPosition();
+}
+
+static void
+wrapToNextLine (void) {
+  ptySetCursorColumn(0);
+  ptyMoveDown1();
+}
+
 void
-ptyAddCharacter (unsigned char character) {
+ptyAddCharacter (wchar_t character) {
+  int width = wcwidth(character);
+  if (width < 1) width = 1;
+
+  /* Resolve a wrap deferred from the previous glyph before placing this one. */
+  if (pendingWrap) {
+    pendingWrap = 0;
+    wrapToNextLine();
+  }
+
+  /* A double-width glyph that no longer fits on the line wraps to the next. */
+  if ((segmentHeader->cursorColumn + width) > segmentHeader->screenWidth) {
+    wrapToNextLine();
+  }
+
   unsigned int row = segmentHeader->cursorRow;
   unsigned int column = segmentHeader->cursorColumn;
 
-  addch(character);
-  storeCursorPosition();
+  writeGlyph(row, column, character);
 
-  setCharacter(row, column, NULL);
+  /* Mirror every cell the glyph occupied (two for a double-width character). */
+  for (unsigned int c=column; (c<(column+width)) && (c<segmentHeader->screenWidth); c+=1) {
+    setCharacter(row, c, NULL);
+  }
+
+  unsigned int newColumn = column + width;
+  if (newColumn < segmentHeader->screenWidth) {
+    moveCursor(row, newColumn);
+  } else {
+    /* The glyph reached the right margin: keep the cursor on the last column
+     * and defer the wrap until the next glyph (xenl behavior). */
+    moveCursor(row, segmentHeader->screenWidth - 1);
+    pendingWrap = 1;
+  }
 }
 
 void
@@ -633,4 +786,70 @@ ptyClearToEndOfDisplay (void) {
     getScreenCharacterArray(segmentHeader, &to);
     propagateScreenCharacter(from, to);
   }
+}
+
+void
+ptyClearToBeginningOfDisplay (void) {
+  unsigned int row = segmentHeader->cursorRow;
+
+  /* Clear every row above the cursor in full. */
+  if (row > 0) {
+    unsigned int savedRow = segmentHeader->cursorRow;
+    unsigned int savedColumn = segmentHeader->cursorColumn;
+
+    for (unsigned int r=0; r<row; r+=1) {
+      moveCursor(r, 0);
+      clrtoeol();
+    }
+
+    fillRows(0, row);
+    moveCursor(savedRow, savedColumn);
+  }
+
+  /* Clear the cursor's own row from its start up to the cursor. */
+  ptyClearToBeginningOfLine();
+}
+
+/* Clear the cursor's entire row, leaving the cursor where it is. */
+void
+ptyClearLine (void) {
+  unsigned int column = segmentHeader->cursorColumn;
+  ptySetCursorColumn(0);
+  ptyClearToEndOfLine();
+  ptySetCursorColumn(column);
+}
+
+/* Clear the whole screen, leaving the cursor where it is (CSI 2J). */
+void
+ptyClearDisplay (void) {
+  unsigned int row = segmentHeader->cursorRow;
+  unsigned int column = segmentHeader->cursorColumn;
+  ptySetCursorPosition(0, 0);
+  ptyClearToEndOfDisplay();
+  ptySetCursorPosition(row, column);
+}
+
+/* Erase count characters at the cursor (overwrite with blanks) without moving
+ * the cursor or shifting the rest of the line (CSI X / ECH). */
+void
+ptyEraseCharacters (unsigned int count) {
+  unsigned int row = segmentHeader->cursorRow;
+  unsigned int column = segmentHeader->cursorColumn;
+
+  unsigned int available = segmentHeader->screenWidth - column;
+  if (count > available) count = available;
+
+  for (unsigned int i=0; i<count; i+=1) {
+    writeGlyph(row, (column + i), ' ');
+    setCharacter(row, (column + i), NULL);
+  }
+
+  pendingWrap = 0;
+  moveCursor(row, column);
+}
+
+void
+ptyGetCursorPosition (unsigned int *row, unsigned int *column) {
+  if (row) *row = segmentHeader->cursorRow;
+  if (column) *column = segmentHeader->cursorColumn;
 }

--- a/Programs/pty_screen.c
+++ b/Programs/pty_screen.c
@@ -19,10 +19,13 @@
 #include "prologue.h"
 
 #include <wchar.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "get_term.h"
 #include "log.h"
 #include "pty_screen.h"
+#include "pty_clipboard.h"
 #include "scr_emulator.h"
 #include "msg_queue.h"
 #include "utf8.h"
@@ -118,6 +121,14 @@ messageHandler_InputText (const MessageHandlerParameters *parameters) {
     if (character == WEOF) break;
     if (!ptyWriteInputCharacter(pty, character, 0)) break;
   }
+}
+
+/* BRLTTY clipboard -> host clipboard bridging, emulator side. The emulator runs
+ * in the GUI session, so it owns the system clipboard; the driver owns BRLTTY's
+ * clipboard and reports a change here whenever a braille copy updates it. */
+static void
+messageHandler_clipboardToHost (const MessageHandlerParameters *parameters) {
+  ptyPublishClipboard(parameters->content, parameters->length);
 }
 
 static void
@@ -367,6 +378,11 @@ ptyBeginScreen (PtyObject *pty, int driverDirectives) {
       haveInputTextHandler = startTerminalMessageReceiver(
         "terminal-input-text-receiver", TERM_MSG_INPUT_TEXT,
         0X200, messageHandler_InputText, pty
+      );
+
+      startTerminalMessageReceiver(
+        "terminal-clipboard-receiver", TERM_MSG_CLIPBOARD_TO_HOST,
+        TERM_CLIPBOARD_MESSAGE_SIZE, messageHandler_clipboardToHost, NULL
       );
 
       return 1;

--- a/Programs/pty_screen.c
+++ b/Programs/pty_screen.c
@@ -132,14 +132,18 @@ static int haveSegmentKey = 0;
 
 static int
 destroySegment (void) {
-  unregisterTerminalResources();
-
   if (haveTerminalMessageQueue) {
     destroyMessageQueue(terminalMessageQueue);
     haveTerminalMessageQueue = 0;
   }
 
-  return destroyScreenSegment(segmentIdentifier);
+  /* Destroy the IPC objects before removing the registry marker that would
+   * let a future instance reap them: if this process is killed between the
+   * two steps, leaving the marker behind means the leak is still reapable
+   * later, rather than becoming permanently untracked. */
+  int result = destroyScreenSegment(segmentIdentifier);
+  unregisterTerminalResources();
+  return result;
 }
 
 static int

--- a/Programs/pty_screen.c
+++ b/Programs/pty_screen.c
@@ -132,6 +132,8 @@ static int haveSegmentKey = 0;
 
 static int
 destroySegment (void) {
+  unregisterTerminalResources();
+
   if (haveTerminalMessageQueue) {
     destroyMessageQueue(terminalMessageQueue);
     haveTerminalMessageQueue = 0;
@@ -296,6 +298,11 @@ ptyBeginScreen (PtyObject *pty, int driverDirectives) {
   haveTerminalMessageQueue = 0;
   haveInputTextHandler = 0;
 
+  /* Reap the shared-memory segment and message queue of any past instance
+   * that was killed uncleanly (crash, force-quit, SIGKILL) before it could
+   * remove them itself - see reapStaleTerminalResources()'s comment. */
+  reapStaleTerminalResources();
+
   /* Make curses size the screen from the real terminal rather than from the
    * inherited LINES/COLUMNS environment variables. Those variables are often
    * stale (commonly left at 80x24) and, when honored, would cap the emulated
@@ -348,6 +355,10 @@ ptyBeginScreen (PtyObject *pty, int driverDirectives) {
     if (createSegment(ptyGetPath(pty), driverDirectives)) {
       segmentHeader->screenNumber = 1;
       storeCursorPosition();
+
+      registerTerminalResources(
+        segmentIdentifier, haveTerminalMessageQueue? terminalMessageQueue: -1
+      );
 
       haveInputTextHandler = startTerminalMessageReceiver(
         "terminal-input-text-receiver", TERM_MSG_INPUT_TEXT,

--- a/Programs/pty_screen.c
+++ b/Programs/pty_screen.c
@@ -21,6 +21,7 @@
 #include <wchar.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/msg.h> /* IPC_NOWAIT */
 
 #include "get_term.h"
 #include "log.h"
@@ -101,7 +102,13 @@ static int haveInputTextHandler = 0;
 static int
 sendTerminalMessage (MessageType type, const void *content, size_t length) {
   if (!haveTerminalMessageQueue) return 0;
-  return sendMessage(terminalMessageQueue, type, content, length, 0);
+
+  /* These are best-effort notifications (segment-updated, emulator-exiting), not
+   * data: send non-blocking. The driver also polls the segment, so a dropped
+   * "updated" hint just defers a braille refresh to the next poll. Blocking here
+   * would stall the whole I/O loop - and thus the child - whenever the daemon is
+   * slow and the small SysV queue fills during a burst of output. */
+  return sendMessage(terminalMessageQueue, type, content, length, IPC_NOWAIT);
 }
 
 static int
@@ -330,16 +337,17 @@ ptyBeginScreen (PtyObject *pty, int driverDirectives) {
 #endif /* NCURSES_VERSION */
 
   if (initscr()) {
-    intrflush(stdscr, FALSE);
-    keypad(stdscr, TRUE);
-
+    /* curses is used only as the in-memory grid that backs the braille segment;
+     * it is never painted to the screen (see ptyRefreshScreen). raw()/noecho()/
+     * nonl() are kept because they are the only thing putting the real tty into
+     * raw mode for our own input reader - there is no separate termios setup.
+     * (keypad/intrflush/idlok/idcok only affect curses input or refresh output,
+     * neither of which we use, so they are omitted.) */
     raw();
     noecho();
     nonl();
 
     scrollok(stdscr, TRUE);
-    idlok(stdscr, TRUE);
-    idcok(stdscr, TRUE);
 
     scrollRegionTop = getbegy(stdscr);
     scrollRegionBottom = getmaxy(stdscr) - 1;
@@ -394,8 +402,11 @@ ptyBeginScreen (PtyObject *pty, int driverDirectives) {
   return 0;
 }
 
+static void releaseAlternateScreen (void);
+
 void
 ptyEndScreen (void) {
+  releaseAlternateScreen();
   endwin();
   sendTerminalMessage(TERM_MSG_EMULATOR_EXITING, NULL, 0);
   detachScreenSegment(segmentHeader);
@@ -410,7 +421,12 @@ ptyResizeScreen (unsigned int height, unsigned int width) {
     return;
   }
 
-  /* Resize the curses screen we render through. */
+  /* A saved alternate-screen grid is sized for the old dimensions; drop it so we
+   * don't later restore a stale grid (the terminal will repaint anyway). */
+  releaseAlternateScreen();
+
+  /* Resize the in-memory curses grid (it backs the braille segment and is never
+   * painted to the screen). */
   if (is_term_resized(height, width)) {
     resize_term(height, width);
   }
@@ -450,7 +466,7 @@ ptyResizeScreen (unsigned int height, unsigned int width) {
   if (savedCursorRow >= height) savedCursorRow = height - 1;
   if (savedCursorColumn >= width) savedCursorColumn = width - 1;
 
-  /* Mirror the (resized) curses screen into the fresh segment so the new
+  /* Mirror the (resized) in-memory grid into the fresh segment so the new
    * dimensions are immediately populated; the child repaints on its own
    * SIGWINCH soon after. */
   storeCursorPosition();
@@ -467,8 +483,11 @@ ptyResizeScreen (unsigned int height, unsigned int width) {
 
 void
 ptyRefreshScreen (void) {
+  /* The outer terminal is painted from the child's raw output (see the display
+   * passthrough in pty_terminal.c); the curses grid is kept in memory only and
+   * read back to fill the braille segment, so it is never painted to the real
+   * screen. We just announce that the segment changed. */
   sendTerminalMessage(TERM_MSG_SEGMENT_UPDATED, NULL, 0);
-  refresh();
 }
 
 void
@@ -497,6 +516,109 @@ ptySaveCursorPosition (void) {
 void
 ptyRestoreCursorPosition (void) {
   ptySetCursorPosition(savedCursorRow, savedCursorColumn);
+}
+
+/* Alternate-screen (smcup/rmcup, DECSET/RST 1049) support for the braille grid.
+ * The outer terminal does the real alternate screen via passthrough; we mirror
+ * it for braille by saving the grid on enter and restoring it on exit, so that
+ * after a full-screen program quits the braille user can review the screen the
+ * terminal restored instead of a blank grid. We save the raw curses cells (so
+ * attributes and colour survive exactly), then mirror them back into the
+ * segment the same way a resize does. */
+#ifdef GOT_CURSES_WCH
+typedef cchar_t SavedCell;
+#else /* GOT_CURSES_WCH */
+typedef chtype SavedCell;
+#endif /* GOT_CURSES_WCH */
+
+static SavedCell *alternateScreen = NULL;
+static unsigned int alternateScreenRows = 0;
+static unsigned int alternateScreenColumns = 0;
+static unsigned int alternateCursorRow = 0;
+static unsigned int alternateCursorColumn = 0;
+
+static void
+releaseAlternateScreen (void) {
+  if (alternateScreen) {
+    free(alternateScreen);
+    alternateScreen = NULL;
+  }
+
+  alternateScreenRows = 0;
+  alternateScreenColumns = 0;
+}
+
+void
+ptyEnterAlternateScreen (void) {
+  /* Save the current grid (unless we already have one saved - nested smcup). */
+  if (!alternateScreen) {
+    unsigned int rows = segmentHeader->screenHeight;
+    unsigned int width = segmentHeader->screenWidth;
+    SavedCell *cells = malloc((size_t)rows * width * sizeof(*cells));
+
+    if (cells) {
+      alternateScreen = cells;
+      alternateScreenRows = rows;
+      alternateScreenColumns = width;
+      alternateCursorRow = segmentHeader->cursorRow;
+      alternateCursorColumn = segmentHeader->cursorColumn;
+
+      for (unsigned int row=0; row<rows; row+=1) {
+        for (unsigned int column=0; column<width; column+=1) {
+          move(row, column);
+        #ifdef GOT_CURSES_WCH
+          in_wch(&cells[(row * width) + column]);
+        #else /* GOT_CURSES_WCH */
+          cells[(row * width) + column] = inch();
+        #endif /* GOT_CURSES_WCH */
+        }
+      }
+    }
+  }
+
+  /* Present a cleared screen to the full-screen program. */
+  ptySetCursorPosition(0, 0);
+  ptyClearToEndOfDisplay();
+}
+
+void
+ptyExitAlternateScreen (void) {
+  unsigned int rows = segmentHeader->screenHeight;
+  unsigned int width = segmentHeader->screenWidth;
+
+  /* If we have no saved grid, or it no longer fits (the screen was resized while
+   * in the alternate screen), we cannot restore it - just clear, as before. */
+  if (!alternateScreen ||
+      (alternateScreenRows != rows) || (alternateScreenColumns != width)) {
+    releaseAlternateScreen();
+    ptySetCursorPosition(0, 0);
+    ptyClearToEndOfDisplay();
+    return;
+  }
+
+  /* Write the saved cells back into the curses grid (without scrolling at the
+   * bottom-right corner), then mirror the whole grid into the segment. */
+  scrollok(stdscr, FALSE);
+  for (unsigned int row=0; row<rows; row+=1) {
+    for (unsigned int column=0; column<width; column+=1) {
+      move(row, column);
+    #ifdef GOT_CURSES_WCH
+      add_wch(&alternateScreen[(row * width) + column]);
+    #else /* GOT_CURSES_WCH */
+      addch(alternateScreen[(row * width) + column]);
+    #endif /* GOT_CURSES_WCH */
+    }
+  }
+  scrollok(stdscr, TRUE);
+
+  for (unsigned int row=0; row<rows; row+=1) {
+    for (unsigned int column=0; column<width; column+=1) {
+      setCharacter(row, column, NULL);
+    }
+  }
+
+  ptySetCursorPosition(alternateCursorRow, alternateCursorColumn);
+  releaseAlternateScreen();
 }
 
 void
@@ -738,11 +860,6 @@ ptyAddCharacter (wchar_t character) {
     moveCursor(row, segmentHeader->screenWidth - 1);
     pendingWrap = 1;
   }
-}
-
-void
-ptySetCursorVisibility (unsigned int visibility) {
-  curs_set(visibility);
 }
 
 void

--- a/Programs/pty_terminal.c
+++ b/Programs/pty_terminal.c
@@ -132,10 +132,7 @@ ptyGetTerminalType (void) {
 }
 
 static unsigned char insertMode = 0;
-static unsigned char keypadTransmitMode = 0;   /* DECKPAM: application keypad   */
 static unsigned char cursorKeyMode = 0;        /* DECCKM: application cursor keys */
-static unsigned char bracketedPasteMode = 0;
-static unsigned char absoluteCursorAddressingMode = 0;
 
 /* Character-set state for VT100 line drawing. An app designates G0/G1 as the
  * DEC special graphics set ("ESC ( 0" / "ESC ) 0") and switches between them
@@ -165,10 +162,7 @@ static void ptyResetTerminalInput (PtyObject *pty);
 int
 ptyBeginTerminal (PtyObject *pty, int driverDirectives) {
   insertMode = 0;
-  keypadTransmitMode = 0;
   cursorKeyMode = 0;
-  bracketedPasteMode = 0;
-  absoluteCursorAddressingMode = 0;
 
   charsetShiftedOut = 0;
   g0GraphicsCharset = 0;
@@ -197,15 +191,6 @@ ptyResizeTerminal (unsigned int height, unsigned int width) {
   ptyResizeScreen(height, width);
 }
 
-static void
-soundAlert (void) {
-  beep();
-}
-
-static void
-showAlert (void) {
-  flash();
-}
 
 /* Keyboard input parser.
  *
@@ -626,10 +611,87 @@ addTextCharacter (wchar_t character) {
   lastTextCharacter = character;
 }
 
+/* Display: brltty-pty writes the child's output straight to the outer terminal,
+ * which renders it with full fidelity (true colour, and anything new it
+ * supports). The curses grid is still maintained - it is never painted to the
+ * real screen, only read back to fill the braille segment - so braille is
+ * unchanged. brltty-pty is a single-child observer (unlike tmux, which must
+ * composite panes and therefore render itself), so it can let the terminal do
+ * the rendering.
+ *
+ * A few sequences must NOT reach the outer terminal, because we act on them
+ * ourselves and a second actor would conflict: device-attribute/status queries
+ * (we answer them), the keypad and application-cursor modes and keyboard-
+ * protocol negotiation (we use them to encode braille/host input), and OSC 52
+ * (we publish it via ptyPublishClipboard). Each such handler calls
+ * suppressPassthroughUnit().
+ */
+static unsigned char passthroughUnit[0X2000];
+static size_t passthroughUnitLength = 0;
+static int passthroughSuppress = 0;
+
+static void
+writeOuterTerminal (const unsigned char *bytes, size_t count) {
+  while (count > 0) {
+    ssize_t written = write(STDOUT_FILENO, bytes, count);
+
+    if (written < 0) {
+      if (errno == EINTR) continue;
+      break;
+    }
+
+    bytes += written;
+    count -= (size_t)written;
+  }
+}
+
+/* Reset the per-unit passthrough capture (called at the start of each unit). */
+static void
+beginPassthroughUnit (void) {
+  passthroughUnitLength = 0;
+  passthroughSuppress = 0;
+}
+
+/* Mark the current sequence as one we consume ourselves: drop what we have
+ * captured and stop capturing the rest, so it never reaches the outer terminal.
+ * Called early enough (e.g. as soon as an OSC is recognized as OSC 52) that even
+ * a large payload never leaks. */
+static void
+suppressPassthroughUnit (void) {
+  passthroughSuppress = 1;
+  passthroughUnitLength = 0;
+}
+
+static void
+capturePassthroughByte (unsigned char byte) {
+  if (passthroughSuppress) return;
+
+  if (passthroughUnitLength == sizeof(passthroughUnit)) {
+    /* A long, non-suppressed sequence (e.g. a very long window title): emit
+     * what we have and keep going. Suppressed sequences are recognized well
+     * before this, so they never reach here. */
+    writeOuterTerminal(passthroughUnit, passthroughUnitLength);
+    passthroughUnitLength = 0;
+  }
+
+  passthroughUnit[passthroughUnitLength++] = byte;
+}
+
+/* Emit the captured bytes of a completed unit, unless it was suppressed. */
+static void
+flushPassthroughUnit (void) {
+  if (!passthroughSuppress && passthroughUnitLength) {
+    writeOuterTerminal(passthroughUnit, passthroughUnitLength);
+  }
+
+  passthroughUnitLength = 0;
+}
+
 /* Reply to a device query by writing the response to the child as if typed. */
 static void
 sendDeviceResponse (const char *response) {
   if (inputPty) ptyWriteInputData(inputPty, response, strlen(response));
+  suppressPassthroughUnit(); /* the query is ours to answer; don't echo it on */
 }
 
 static OutputByteParserResult
@@ -645,7 +707,7 @@ parseOutputByte_BASIC (unsigned char byte) {
 
     case ASCII_BEL:
       logOutputAction("bel", "audible alert");
-      soundAlert();
+      /* passed through: the outer terminal rings the bell */
       return OBP_DONE;
 
     case ASCII_BS:
@@ -742,12 +804,12 @@ parseOutputByte_ESCAPE (unsigned char byte) {
 
     case '=':
       logOutputAction("smkx", "keypad transmit on");
-      keypadTransmitMode = 1;
+      /* passed through: the terminal handles application keypad, and its keypad
+       * sequences are forwarded verbatim by our input parser */
       return OBP_DONE;
 
     case '>':
       logOutputAction("rmkx", "keypad transmit off");
-      keypadTransmitMode = 0;
       return OBP_DONE;
 
     case 'E':
@@ -767,14 +829,22 @@ parseOutputByte_ESCAPE (unsigned char byte) {
       return OBP_DONE;
 
     case 'c':
-      logOutputAction("clear", "clear screen");
+      logOutputAction("ris", "reset to initial state");
+      /* RIS is a full reset, not just a clear: drop the modes and attributes we
+       * track so the grid matches the freshly-reset terminal. */
+      insertMode = 0;
+      cursorKeyMode = 0;
+      charsetShiftedOut = 0;
+      g0GraphicsCharset = 0;
+      g1GraphicsCharset = 0;
+      ptySetAttributes(A_NORMAL);
       ptySetCursorPosition(0, 0);
       ptyClearToEndOfDisplay();
       return OBP_DONE;
 
     case 'g':
       logOutputAction("flash", "visual alert");
-      showAlert();
+      /* passed through: the outer terminal does the visual bell */
       return OBP_DONE;
 
     case '7':
@@ -849,6 +919,13 @@ appendOscByte (unsigned char byte) {
   }
 
   oscBuffer[oscLength++] = byte;
+
+  /* As soon as an OSC is recognized as OSC 52, suppress it from passthrough: we
+   * publish it ourselves (ptyPublishClipboard), and this keeps even a large
+   * clipboard payload from ever reaching the outer terminal. */
+  if ((oscLength == 3) && (memcmp(oscBuffer, "52;", 3) == 0)) {
+    suppressPassthroughUnit();
+  }
 }
 
 static int
@@ -918,7 +995,13 @@ handleClipboardRequest (char *payload) {
 
 static void
 handleOscString (void) {
-  if (oscOverflow) return;
+  if (oscOverflow) {
+    /* The OSC outgrew oscBuffer (e.g. a clipboard payload over ~64 KiB) and was
+     * truncated, so we can't act on it; drop it rather than use partial data. */
+    logMessage(terminalLogLevel, "OSC string too large; dropped");
+    return;
+  }
+
   oscBuffer[oscLength] = 0;
 
   if (strncmp(oscBuffer, "52;", 3) == 0) {
@@ -1033,7 +1116,7 @@ performBracketAction_h (unsigned char byte) {
 
       case 34:
         logOutputAction("cnorm", "cursor normal visibility");
-        ptySetCursorVisibility(1);
+        /* passed through: cursor visibility is the terminal's to show */
         return OBP_DONE;
     }
   }
@@ -1051,8 +1134,8 @@ performBracketAction_l (unsigned char byte) {
         return OBP_DONE;
 
       case 34:
-        logOutputAction("cvvis", "cursor very visile");
-        ptySetCursorVisibility(2);
+        logOutputAction("cvvis", "cursor very visible");
+        /* passed through: cursor visibility is the terminal's to show */
         return OBP_DONE;
     }
   }
@@ -1476,13 +1559,17 @@ performBracketAction (unsigned char byte) {
       /* "CSI > ... m" is XTMODKEYS (modifyOtherKeys) keyboard-protocol
        * negotiation, not SGR. Swallow it rather than mistaking the parameters
        * for graphic renditions (e.g. turning on underline/dim). */
-      if (outputParserGreaterThan) return OBP_DONE;
+      if (outputParserGreaterThan) {
+        suppressPassthroughUnit(); /* we don't negotiate keyboard protocols */
+        return OBP_DONE;
+      }
       return performBracketAction_m(byte);
 
     case 'u':
       /* "CSI ... u" is the kitty keyboard-protocol negotiation (push/pop/set
        * the keyboard mode). We don't drive the host into those modes, so just
        * consume it - it must never reach the screen as text. */
+      suppressPassthroughUnit(); /* we don't negotiate keyboard protocols */
       return OBP_DONE;
 
     case 'r': {
@@ -1515,28 +1602,26 @@ performQuestionMarkAction_h (unsigned char byte) {
       case 1:
         logOutputAction("DECCKM", "application cursor keys on");
         cursorKeyMode = 1;
+        suppressPassthroughUnit(); /* we encode cursor keys ourselves */
         return OBP_DONE;
 
       case 25:
         logOutputAction("cnorm", "cursor normal visibility");
-        ptySetCursorVisibility(1);
+        /* passed through: cursor visibility is the terminal's to show */
         return OBP_DONE;
 
       case 1049:
-        logOutputAction("smcup", "absolute cursor addressing on");
-        absoluteCursorAddressingMode = 1;
-        /* Entering the alternate screen presents a cleared buffer (this is
-         * what xterm's ?1049 does). We have only one buffer, so emulate it by
-         * saving the cursor and clearing the screen; otherwise a full-screen
-         * program (e.g. Claude Code) draws on top of the previous contents. */
-        ptySaveCursorPosition();
-        ptySetCursorPosition(0, 0);
-        ptyClearToEndOfDisplay();
+        logOutputAction("smcup", "enter alternate screen");
+        /* Save the current grid and present a cleared screen, mirroring the
+         * terminal's alternate screen so braille tracks it (and can be restored
+         * when the full-screen program exits). */
+        ptyEnterAlternateScreen();
         return OBP_DONE;
 
       case 2004:
         logOutputAction("smbp", "bracketed paste on");
-        bracketedPasteMode = 1;
+        /* passed through: the terminal brackets pastes; our input parser
+         * forwards the wrapped paste verbatim to the child */
         return OBP_DONE;
     }
   }
@@ -1551,28 +1636,23 @@ performQuestionMarkAction_l (unsigned char byte) {
       case 1:
         logOutputAction("DECCKM", "application cursor keys off");
         cursorKeyMode = 0;
+        suppressPassthroughUnit(); /* we encode cursor keys ourselves */
         return OBP_DONE;
 
       case 25:
         logOutputAction("civis", "cursor invisible");
-        ptySetCursorVisibility(0);
+        /* passed through: cursor visibility is the terminal's to show */
         return OBP_DONE;
 
       case 1049:
-        logOutputAction("rmcup", "absolute cursor addressing off");
-        absoluteCursorAddressingMode = 0;
-        /* Leaving the alternate screen would normally restore the primary
-         * screen. We can't restore it (single buffer), but we must not leave
-         * the full-screen program's last frame behind as stale text; clear it
-         * and put the cursor back where it was before smcup. */
-        ptySetCursorPosition(0, 0);
-        ptyClearToEndOfDisplay();
-        ptyRestoreCursorPosition();
+        logOutputAction("rmcup", "leave alternate screen");
+        /* Restore the grid saved on smcup so braille shows the screen the
+         * terminal restored (falls back to clearing if nothing was saved). */
+        ptyExitAlternateScreen();
         return OBP_DONE;
 
       case 2004:
         logOutputAction("rmbp", "bracketed paste off");
-        bracketedPasteMode = 0;
         return OBP_DONE;
     }
   }
@@ -1596,7 +1676,7 @@ performQuestionMarkAction (unsigned char byte) {
 static OutputByteParserResult
 parseOutputByte_ACTION (unsigned char byte) {
   if ((byte >= 0X20) && (byte <= 0X2F)) {
-    /* CSI intermediate byte (e.g. the space in "\e[5 q" to set the
+    /* CSI intermediate byte (e.g. the space in "\E[5 q" to set the
      * cursor shape). Consume it and wait for the final byte so the
      * whole sequence is swallowed as a unit rather than leaking.
      */
@@ -1639,11 +1719,14 @@ static int
 parseOutputByte (unsigned char byte) {
   if (outputParserState == OPS_BASIC) {
     outputByteCount = 0;
+    beginPassthroughUnit();
   }
 
   if (outputByteCount < ARRAY_COUNT(outputByteBuffer)) {
     outputByteBuffer[outputByteCount++] = byte;
   }
+
+  capturePassthroughByte(byte);
 
   while (1) {
     OutputByteParserResult result = outputParserStateTable[outputParserState].parseOutputByte(byte);
@@ -1658,6 +1741,7 @@ parseOutputByte (unsigned char byte) {
 
       case OBP_DONE:
         outputParserState = OPS_BASIC;
+        flushPassthroughUnit();
         return 1;
 
       case OBP_CONTINUE:

--- a/Programs/pty_terminal.c
+++ b/Programs/pty_terminal.c
@@ -911,7 +911,7 @@ handleClipboardRequest (char *payload) {
   unsigned char *bytes = decodeBase64(data, &length);
 
   if (bytes) {
-    if (length > 0) ptySetSystemClipboard((const char *)bytes, length);
+    if (length > 0) ptyPublishClipboard((const char *)bytes, length);
     free(bytes);
   }
 }

--- a/Programs/pty_terminal.c
+++ b/Programs/pty_terminal.c
@@ -21,24 +21,27 @@
  * hts=\EH - set tab
  * kmous=\E[M - mouse event
  * tbc=\E[3g - clear all tabs
- * u6=\E[%i%d;%dR - user string 6
- * u7=\E[6n - user string 7
- * u8=\E[?1;2c - user string 8
- * u9=\E[c - user string 9
  */
 
 #include "prologue.h"
 
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include "log.h"
 #include "strfmt.h"
 #include "pty_terminal.h"
 #include "pty_screen.h"
+#include "pty_clipboard.h"
 #include "scr_types.h"
 #include "color.h"
 #include "get_term.h"
 #include "ascii.h"
+#include "utf8.h"
+#include "async_handle.h"
+#include "async_alarm.h"
 
 static unsigned char terminalLogLevel = LOG_DEBUG;
 static unsigned char logInput = 0;
@@ -129,24 +132,63 @@ ptyGetTerminalType (void) {
 }
 
 static unsigned char insertMode = 0;
-static unsigned char alternateCharsetMode = 0;
-static unsigned char keypadTransmitMode = 0;
+static unsigned char keypadTransmitMode = 0;   /* DECKPAM: application keypad   */
+static unsigned char cursorKeyMode = 0;        /* DECCKM: application cursor keys */
 static unsigned char bracketedPasteMode = 0;
 static unsigned char absoluteCursorAddressingMode = 0;
+
+/* Character-set state for VT100 line drawing. An app designates G0/G1 as the
+ * DEC special graphics set ("ESC ( 0" / "ESC ) 0") and switches between them
+ * with SO/SI; while a graphics set is active, letters render as box-drawing
+ * glyphs. We translate those to the Unicode equivalents so braille shows real
+ * lines rather than "qqqq". */
+static unsigned char charsetShiftedOut = 0;    /* SO active -> G1 selected */
+static unsigned char g0GraphicsCharset = 0;    /* G0 designated as graphics */
+static unsigned char g1GraphicsCharset = 0;    /* G1 designated as graphics */
+static unsigned char charsetDesignator = 0;    /* pending ESC ( ) * + introducer */
+
+/* The most recently printed glyph, for the "repeat" control (CSI b / REP). */
+static wchar_t lastTextCharacter = ' ';
+
+/* OSC (operating system command) capture, for OSC 52 clipboard support. Only
+ * OSC strings (introduced by "ESC ]") are buffered; other string controls
+ * (DCS/PM/APC) are consumed without buffering. */
+static unsigned char outputStringIsOsc = 0;
+static char oscBuffer[0X10000];
+static unsigned int oscLength = 0;
+static unsigned char oscOverflow = 0;
+
+static Utf8StreamDecoder textDecoder;
+
+static void ptyResetTerminalInput (PtyObject *pty);
 
 int
 ptyBeginTerminal (PtyObject *pty, int driverDirectives) {
   insertMode = 0;
-  alternateCharsetMode = 0;
   keypadTransmitMode = 0;
+  cursorKeyMode = 0;
   bracketedPasteMode = 0;
   absoluteCursorAddressingMode = 0;
+
+  charsetShiftedOut = 0;
+  g0GraphicsCharset = 0;
+  g1GraphicsCharset = 0;
+  charsetDesignator = 0;
+  lastTextCharacter = ' ';
+
+  outputStringIsOsc = 0;
+  oscLength = 0;
+  oscOverflow = 0;
+
+  memset(&textDecoder, 0, sizeof(textDecoder));
+  ptyResetTerminalInput(pty);
 
   return ptyBeginScreen(pty, driverDirectives);
 }
 
 void
 ptyEndTerminal (void) {
+  ptyResetTerminalInput(NULL);
   ptyEndScreen();
 }
 
@@ -165,117 +207,313 @@ showAlert (void) {
   flash();
 }
 
-int
-ptyProcessTerminalInput (PtyObject *pty) {
-  int character = getch();
+/* Keyboard input parser.
+ *
+ * Rather than letting curses decode keys (which depends on the *host* terminal's
+ * terminfo, silently drops modified keys it has no capability for, and strands
+ * bytes in its own buffer behind a select() loop), we read the host's raw bytes
+ * and parse the escape sequences ourselves - the approach tmux takes in
+ * tty-keys.c. Recognized cursor/navigation/function keys are re-encoded for the
+ * child by ptyWriteInputCharacter() (honoring the child's application-cursor
+ * mode and any modifiers); everything else - printable text, UTF-8, control
+ * bytes, Alt/meta combinations, and any sequence we don't recognize - is passed
+ * through to the child verbatim so nothing is ever lost.
+ */
 
-  if (logInput) {
-    const char *name = keyname(character);
-    if (!name) name = "unknown";
-    logMessage(terminalLogLevel, "input: 0X%02X (%s)", character, name);
+/* How long to wait for the rest of an escape sequence before deciding a lone
+ * ESC really was the Escape key (and flushing any half-finished sequence). */
+#define INPUT_ESCAPE_TIMEOUT 100
+
+typedef enum {
+  IPS_GROUND,  /* between sequences */
+  IPS_ESCAPE,  /* seen ESC */
+  IPS_CSI,     /* seen ESC [ , collecting parameters */
+  IPS_SS3,     /* seen ESC O , expecting one final byte */
+} InputParserState;
+
+static PtyObject *inputPty = NULL;
+static InputParserState inputState = IPS_GROUND;
+static unsigned char inputBuffer[0X20];
+static unsigned int inputCount = 0;
+static AsyncHandle inputTimeoutAlarm = NULL;
+
+static int
+forwardInputBytes (const unsigned char *bytes, size_t count) {
+  return ptyWriteInputData(inputPty, bytes, count);
+}
+
+static void
+resetInputParser (void) {
+  inputState = IPS_GROUND;
+  inputCount = 0;
+}
+
+static int
+appendInputByte (unsigned char byte) {
+  if (inputCount < ARRAY_COUNT(inputBuffer)) {
+    inputBuffer[inputCount++] = byte;
+    return 1;
   }
 
-  if (character > UINT8_MAX) {
-    ScreenKey key = 0;
+  return 0;
+}
 
-    #define KEY(from, to) case KEY_##from: key = SCR_KEY_##to; break;
-    switch (character) {
-      KEY(ENTER    , ENTER)
-      KEY(BACKSPACE, BACKSPACE)
+/* Translate the modifier flags into ScreenKey bits and emit the key. The
+ * xtermModifier is the standard "1 + bitmask" parameter (shift=1, alt=2,
+ * ctrl=4); values below 2 mean no modifier. */
+static void
+emitMappedKey (ScreenKey base, unsigned int xtermModifier) {
+  ScreenKey key = base;
 
-      KEY(LEFT     , CURSOR_LEFT)
-      KEY(RIGHT    , CURSOR_RIGHT)
-      KEY(UP       , CURSOR_UP)
-      KEY(DOWN     , CURSOR_DOWN)
+  if (xtermModifier >= 2) {
+    unsigned int bits = xtermModifier - 1;
+    if (bits & 1) key |= SCR_KEY_SHIFT;
+    if (bits & 2) key |= SCR_KEY_ALT_LEFT;
+    if (bits & 4) key |= SCR_KEY_CONTROL;
+  }
 
-      KEY(PPAGE    , PAGE_UP)
-      KEY(NPAGE    , PAGE_DOWN)
-      KEY(HOME     , HOME)
-      KEY(END      , END)
-      KEY(IC       , INSERT)
-      KEY(DC       , DELETE)
+  ptyWriteInputCharacter(inputPty, key, cursorKeyMode);
+}
 
-      KEY(F( 1)    , F1)
-      KEY(F( 2)    , F2)
-      KEY(F( 3)    , F3)
-      KEY(F( 4)    , F4)
-      KEY(F( 5)    , F5)
-      KEY(F( 6)    , F6)
-      KEY(F( 7)    , F7)
-      KEY(F( 8)    , F8)
-      KEY(F( 9)    , F9)
-      KEY(F(10)    , F10)
-      KEY(F(11)    , F11)
-      KEY(F(12)    , F12)
-      KEY(F(13)    , F13)
-      KEY(F(14)    , F14)
-      KEY(F(15)    , F15)
-      KEY(F(16)    , F16)
-      KEY(F(17)    , F17)
-      KEY(F(18)    , F18)
-      KEY(F(19)    , F19)
-      KEY(F(20)    , F20)
-      KEY(F(21)    , F21)
-      KEY(F(22)    , F22)
-      KEY(F(23)    , F23)
-      KEY(F(24)    , F24)
-      KEY(F(25)    , F25)
-      KEY(F(26)    , F26)
-      KEY(F(27)    , F27)
-      KEY(F(28)    , F28)
-      KEY(F(29)    , F29)
-      KEY(F(30)    , F30)
-      KEY(F(31)    , F31)
-      KEY(F(32)    , F32)
-      KEY(F(33)    , F33)
-      KEY(F(34)    , F34)
-      KEY(F(35)    , F35)
-      KEY(F(36)    , F36)
-      KEY(F(37)    , F37)
-      KEY(F(38)    , F38)
-      KEY(F(39)    , F39)
-      KEY(F(40)    , F40)
-      KEY(F(41)    , F41)
-      KEY(F(42)    , F42)
-      KEY(F(43)    , F43)
-      KEY(F(44)    , F44)
-      KEY(F(45)    , F45)
-      KEY(F(46)    , F46)
-      KEY(F(47)    , F47)
-      KEY(F(48)    , F48)
-      KEY(F(49)    , F49)
-      KEY(F(50)    , F50)
-      KEY(F(51)    , F51)
-      KEY(F(52)    , F52)
-      KEY(F(53)    , F53)
-      KEY(F(54)    , F54)
-      KEY(F(55)    , F55)
-      KEY(F(56)    , F56)
-      KEY(F(57)    , F57)
-      KEY(F(58)    , F58)
-      KEY(F(59)    , F59)
-      KEY(F(60)    , F60)
-      KEY(F(61)    , F61)
-      KEY(F(62)    , F62)
-      KEY(F(63)    , F63)
-    }
-    #undef KEY
+static ScreenKey
+finalLetterToKey (unsigned char final) {
+  switch (final) {
+    case 'A': return SCR_KEY_CURSOR_UP;
+    case 'B': return SCR_KEY_CURSOR_DOWN;
+    case 'C': return SCR_KEY_CURSOR_RIGHT;
+    case 'D': return SCR_KEY_CURSOR_LEFT;
+    case 'H': return SCR_KEY_HOME;
+    case 'F': return SCR_KEY_END;
+    case 'P': return SCR_KEY_F1;
+    case 'Q': return SCR_KEY_F2;
+    case 'R': return SCR_KEY_F3;
+    case 'S': return SCR_KEY_F4;
+    default:  return 0;
+  }
+}
 
-    if (key) {
-      if (!ptyWriteInputCharacter(pty, key, keypadTransmitMode)) {
-        return 0;
+static ScreenKey
+tildeNumberToKey (unsigned int number) {
+  switch (number) {
+    case  1: case 7: return SCR_KEY_HOME;
+    case  2: return SCR_KEY_INSERT;
+    case  3: return SCR_KEY_DELETE;
+    case  4: case 8: return SCR_KEY_END;
+    case  5: return SCR_KEY_PAGE_UP;
+    case  6: return SCR_KEY_PAGE_DOWN;
+    case 11: return SCR_KEY_F1;
+    case 12: return SCR_KEY_F2;
+    case 13: return SCR_KEY_F3;
+    case 14: return SCR_KEY_F4;
+    case 15: return SCR_KEY_F5;
+    case 17: return SCR_KEY_F6;
+    case 18: return SCR_KEY_F7;
+    case 19: return SCR_KEY_F8;
+    case 20: return SCR_KEY_F9;
+    case 21: return SCR_KEY_F10;
+    case 23: return SCR_KEY_F11;
+    case 24: return SCR_KEY_F12;
+    case 25: return SCR_KEY_F13;
+    case 26: return SCR_KEY_F14;
+    case 28: return SCR_KEY_F15;
+    case 29: return SCR_KEY_F16;
+    case 31: return SCR_KEY_F17;
+    case 32: return SCR_KEY_F18;
+    case 33: return SCR_KEY_F19;
+    case 34: return SCR_KEY_F20;
+    default: return 0;
+  }
+}
+
+/* Interpret a complete "ESC [ ... final" sequence in inputBuffer. */
+static void
+handleControlSequence (void) {
+  unsigned char final = inputBuffer[inputCount - 1];
+
+  unsigned int parameters[2] = {0, 0};
+  unsigned int parameterCount = 0;
+  int haveDigit = 0;
+  int unsupported = 0;
+
+  for (unsigned int i=2; i<(inputCount-1); i+=1) {
+    unsigned char byte = inputBuffer[i];
+
+    if ((byte >= '0') && (byte <= '9')) {
+      if (parameterCount < ARRAY_COUNT(parameters)) {
+        parameters[parameterCount] = (parameters[parameterCount] * 10) + (byte - '0');
       }
-    } else if (logUnexpected) {
-      const char *name = keyname(character);
-      if (!name) name = "unknown";
-      logMessage(terminalLogLevel, "unexpected input: 0X%02X (%s)", character, name);
+      haveDigit = 1;
+    } else if (byte == ';') {
+      if (parameterCount < ARRAY_COUNT(parameters)) parameterCount += 1;
+      haveDigit = 0;
+    } else {
+      /* private markers ('?', '>', '<') or intermediates - not a key */
+      unsupported = 1;
+      break;
+    }
+  }
+
+  if (haveDigit && (parameterCount < ARRAY_COUNT(parameters))) parameterCount += 1;
+
+  if (!unsupported) {
+    ScreenKey base = 0;
+    unsigned int modifier = (parameterCount >= 2)? parameters[1]: 0;
+
+    if (final == '~') {
+      base = tildeNumberToKey((parameterCount >= 1)? parameters[0]: 0);
+    } else {
+      base = finalLetterToKey(final);
+    }
+
+    if (base) {
+      emitMappedKey(base, modifier);
+      return;
+    }
+  }
+
+  /* Unrecognized: forward verbatim so the child still gets it. */
+  forwardInputBytes(inputBuffer, inputCount);
+}
+
+static void
+handleSingleShift3 (unsigned char final) {
+  ScreenKey base = finalLetterToKey(final);
+
+  if (base) {
+    emitMappedKey(base, 0);
+  } else {
+    forwardInputBytes(inputBuffer, inputCount);
+  }
+}
+
+static void
+processInputByte (unsigned char byte) {
+  switch (inputState) {
+    case IPS_GROUND:
+      if (byte == ASCII_ESC) {
+        inputCount = 0;
+        appendInputByte(byte);
+        inputState = IPS_ESCAPE;
+      } else {
+        forwardInputBytes(&byte, 1);
+      }
+      break;
+
+    case IPS_ESCAPE:
+      if (byte == '[') {
+        appendInputByte(byte);
+        inputState = IPS_CSI;
+      } else if (byte == 'O') {
+        appendInputByte(byte);
+        inputState = IPS_SS3;
+      } else if (byte == ASCII_ESC) {
+        /* ESC ESC: emit one Escape and start a fresh sequence. */
+        unsigned char esc = ASCII_ESC;
+        forwardInputBytes(&esc, 1);
+        inputCount = 0;
+        appendInputByte(byte);
+      } else {
+        /* Alt/Meta + byte: the child's encoding is exactly ESC then the byte. */
+        unsigned char sequence[2] = {ASCII_ESC, byte};
+        forwardInputBytes(sequence, sizeof(sequence));
+        resetInputParser();
+      }
+      break;
+
+    case IPS_CSI:
+      if ((byte >= 0X40) && (byte <= 0X7E)) {       /* final byte */
+        appendInputByte(byte);
+        handleControlSequence();
+        resetInputParser();
+      } else if ((byte >= 0X20) && (byte <= 0X3F)) { /* parameter / intermediate */
+        if (!appendInputByte(byte)) {                /* overflow - give up cleanly */
+          forwardInputBytes(inputBuffer, inputCount);
+          resetInputParser();
+        }
+      } else {
+        /* Stray byte inside a CSI: flush what we have and reprocess it. */
+        forwardInputBytes(inputBuffer, inputCount);
+        resetInputParser();
+        processInputByte(byte);
+      }
+      break;
+
+    case IPS_SS3:
+      if ((byte >= 0X40) && (byte <= 0X7E)) {
+        appendInputByte(byte);
+        handleSingleShift3(byte);
+        resetInputParser();
+      } else {
+        forwardInputBytes(inputBuffer, inputCount);
+        resetInputParser();
+        processInputByte(byte);
+      }
+      break;
+  }
+}
+
+ASYNC_ALARM_CALLBACK(handleInputEscapeTimeout) {
+  asyncDiscardHandle(inputTimeoutAlarm);
+  inputTimeoutAlarm = NULL;
+
+  /* The rest of a sequence never arrived: a lone ESC was the Escape key, and a
+   * half-finished CSI/SS3 is passed through as-is. */
+  if (inputState != IPS_GROUND) {
+    forwardInputBytes(inputBuffer, inputCount);
+    resetInputParser();
+  }
+}
+
+static void
+cancelInputEscapeTimeout (void) {
+  if (inputTimeoutAlarm) {
+    asyncCancelRequest(inputTimeoutAlarm);
+    inputTimeoutAlarm = NULL;
+  }
+}
+
+static void
+armInputEscapeTimeout (void) {
+  if (inputTimeoutAlarm) {
+    asyncResetAlarmIn(inputTimeoutAlarm, INPUT_ESCAPE_TIMEOUT);
+  } else {
+    asyncNewRelativeAlarm(&inputTimeoutAlarm, INPUT_ESCAPE_TIMEOUT,
+                          handleInputEscapeTimeout, NULL);
+  }
+}
+
+static void
+ptyResetTerminalInput (PtyObject *pty) {
+  cancelInputEscapeTimeout();
+  resetInputParser();
+  inputPty = pty;
+}
+
+int
+ptyProcessTerminalInput (PtyObject *pty) {
+  inputPty = pty;
+
+  unsigned char buffer[0X200];
+  ssize_t count = read(STDIN_FILENO, buffer, sizeof(buffer));
+
+  if (count > 0) {
+    if (logInput) logBytes(terminalLogLevel, "input", buffer, count);
+    for (ssize_t i=0; i<count; i+=1) processInputByte(buffer[i]);
+
+    /* Wait briefly for the tail of an unfinished sequence; otherwise resolve
+     * immediately so a stalled ESC isn't held back. */
+    if (inputState == IPS_GROUND) {
+      cancelInputEscapeTimeout();
+    } else {
+      armInputEscapeTimeout();
     }
 
     return 1;
   }
 
-  char byte = character;
-  return ptyWriteInputData(pty, &byte,1);
+  if (count == 0) return 0;                          /* end of input */
+  if ((errno == EINTR) || (errno == EAGAIN)) return 1;
+  return 0;
 }
 
 static unsigned char outputByteBuffer[0X40];
@@ -298,10 +536,15 @@ typedef enum {
   OPS_NUMBER,
   OPS_DIGIT,
   OPS_ACTION,
+  OPS_STRING,
+  OPS_STRING_ESCAPE,
+  OPS_DISCARD,
+  OPS_TEXT,
 } OutputParserState;
 
 static OutputParserState outputParserState;
 static unsigned char outputParserQuestionMark;
+static unsigned char outputParserGreaterThan;
 
 static unsigned int outputParserNumber;
 static unsigned int outputParserNumberArray[9];
@@ -346,9 +589,53 @@ typedef enum {
 
 typedef OutputByteParserResult OutputByteParser (unsigned char byte);
 
+/* Map a byte from the DEC special graphics set to its Unicode equivalent so a
+ * braille reader sees real box-drawing/line glyphs instead of plain letters. */
+static wchar_t
+mapGraphicsCharacter (wchar_t character) {
+  static const wchar_t table[] = {
+    /* 0x60 */ 0X25C6, 0X2592, 0X2409, 0X240C, 0X240D, 0X240A, 0X00B0, 0X00B1,
+    /* 0x68 */ 0X2424, 0X240B, 0X2518, 0X2510, 0X250C, 0X2514, 0X253C, 0X23BA,
+    /* 0x70 */ 0X23BB, 0X2500, 0X23BC, 0X23BD, 0X251C, 0X2524, 0X2534, 0X252C,
+    /* 0x78 */ 0X2502, 0X2264, 0X2265, 0X03C0, 0X2260, 0X00A3, 0X00B7,
+  };
+
+  if ((character >= 0X60) && (character <= 0X7E)) {
+    wchar_t mapped = table[character - 0X60];
+    if (mapped) return mapped;
+  }
+
+  return character;
+}
+
+static int
+graphicsCharsetActive (void) {
+  return charsetShiftedOut? g1GraphicsCharset: g0GraphicsCharset;
+}
+
+static void
+addTextCharacter (wchar_t character) {
+  if (graphicsCharsetActive()) character = mapGraphicsCharacter(character);
+
+  if (logOutput) {
+    logMessage(terminalLogLevel, "output: U+%04X", (unsigned int)character);
+  }
+
+  if (insertMode) ptyInsertCharacters(1);
+  ptyAddCharacter(character);
+  lastTextCharacter = character;
+}
+
+/* Reply to a device query by writing the response to the child as if typed. */
+static void
+sendDeviceResponse (const char *response) {
+  if (inputPty) ptyWriteInputData(inputPty, response, strlen(response));
+}
+
 static OutputByteParserResult
 parseOutputByte_BASIC (unsigned char byte) {
   outputParserQuestionMark = 0;
+  outputParserGreaterThan = 0;
   outputParserNumberCount = 0;
 
   switch (byte) {
@@ -387,25 +674,63 @@ parseOutputByte_BASIC (unsigned char byte) {
       return OBP_DONE;
 
     case ASCII_SO:
-      logOutputAction("smacs", "alternate charset on");
-      alternateCharsetMode = 1;
+      logOutputAction("smacs", "shift out to G1");
+      charsetShiftedOut = 1;
       return OBP_DONE;
 
     case ASCII_SI:
-      logOutputAction("rmacs", "alternate charset off");
-      alternateCharsetMode = 0;
+      logOutputAction("rmacs", "shift in to G0");
+      charsetShiftedOut = 0;
       return OBP_DONE;
 
     default: {
-      if (logOutput) {
-        logMessage(terminalLogLevel, "output: 0X%02X", byte);
+      wchar_t character;
+      int reprocess;
+      Utf8DecodeResult result = putUtf8StreamByte(&textDecoder, byte, &character, &reprocess);
+
+      switch (result) {
+        case UTF8_DECODE_PENDING:
+          outputParserState = OPS_TEXT;
+          return OBP_CONTINUE;
+
+        case UTF8_DECODE_DONE:
+        case UTF8_DECODE_INVALID:
+          /* A lone/invalid lead byte never asks to be reprocessed here. */
+          addTextCharacter(character);
+          return OBP_DONE;
       }
 
-      if (insertMode) ptyInsertCharacters(1);
-      ptyAddCharacter(byte);
       return OBP_DONE;
     }
   }
+}
+
+static OutputByteParserResult
+parseOutputByte_TEXT (unsigned char byte) {
+  wchar_t character;
+  int reprocess;
+  Utf8DecodeResult result = putUtf8StreamByte(&textDecoder, byte, &character, &reprocess);
+
+  switch (result) {
+    case UTF8_DECODE_PENDING:
+      return OBP_CONTINUE;
+
+    case UTF8_DECODE_DONE:
+      addTextCharacter(character);
+      outputParserState = OPS_BASIC;
+      return OBP_DONE;
+
+    case UTF8_DECODE_INVALID:
+      /* The multi-byte sequence was truncated; emit the replacement
+       * character for it and, when the offending byte may start a new
+       * character, reprocess it from the base state.
+       */
+      addTextCharacter(character);
+      outputParserState = OPS_BASIC;
+      return reprocess? OBP_REPROCESS: OBP_DONE;
+  }
+
+  return OBP_DONE;
 }
 
 static OutputByteParserResult
@@ -461,20 +786,212 @@ parseOutputByte_ESCAPE (unsigned char byte) {
       logOutputAction("rc", "restore cursor position");
       ptyRestoreCursorPosition();
       return OBP_DONE;
+
+    case ']': /* OSC - operating system command */
+      /* OSC runs until a string terminator (BEL or ESC \). We capture it so
+       * OSC 52 can drive the system clipboard; other OSCs (titles, hyperlinks)
+       * are captured but ignored. */
+      outputStringIsOsc = 1;
+      oscLength = 0;
+      oscOverflow = 0;
+      outputParserState = OPS_STRING;
+      return OBP_CONTINUE;
+
+    case 'P': /* DCS - device control string */
+    case '^': /* PM  - privacy message */
+    case '_': /* APC - application program command */
+      /* We don't act on these, but must consume the whole string so its
+       * payload doesn't leak onto the screen as text. */
+      outputStringIsOsc = 0;
+      outputParserState = OPS_STRING;
+      return OBP_CONTINUE;
+
+    case '\\': /* ST - lone string terminator */
+      return OBP_DONE;
+
+    case '(': /* designate G0 character set (e.g. enacs "\E(B") */
+    case ')': /* designate G1 character set (e.g. is2 "\E)0")   */
+    case '*': /* designate G2 character set */
+    case '+': /* designate G3 character set */
+    case '#': /* DEC line-size / alignment (e.g. DECALN "\E#8") */
+      /* These introducers are followed by exactly one selector byte. We record
+       * a G0/G1 graphics designation (for line drawing) and consume the
+       * selector so it isn't printed as text. */
+      charsetDesignator = byte;
+      outputParserState = OPS_DISCARD;
+      return OBP_CONTINUE;
   }
 
   return OBP_UNEXPECTED;
 }
 
 static OutputByteParserResult
+parseOutputByte_DISCARD (unsigned char byte) {
+  /* The byte is the selector following ESC ( ) * + #. "0" selects the DEC
+   * special graphics (line-drawing) set; anything else (e.g. "B" = ASCII) is
+   * a non-graphics set. We only track G0 and G1. */
+  switch (charsetDesignator) {
+    case '(': g0GraphicsCharset = (byte == '0'); break;
+    case ')': g1GraphicsCharset = (byte == '0'); break;
+    default: break;
+  }
+
+  return OBP_DONE;
+}
+
+static void
+appendOscByte (unsigned char byte) {
+  if (oscOverflow) return;
+
+  if (oscLength >= (sizeof(oscBuffer) - 1)) {
+    oscOverflow = 1;
+    return;
+  }
+
+  oscBuffer[oscLength++] = byte;
+}
+
+static int
+base64Value (unsigned char byte) {
+  if ((byte >= 'A') && (byte <= 'Z')) return byte - 'A';
+  if ((byte >= 'a') && (byte <= 'z')) return byte - 'a' + 26;
+  if ((byte >= '0') && (byte <= '9')) return byte - '0' + 52;
+  if (byte == '+') return 62;
+  if (byte == '/') return 63;
+  return -1;
+}
+
+/* Decode base64 text into a freshly allocated buffer (caller frees). */
+static unsigned char *
+decodeBase64 (const char *text, size_t *length) {
+  size_t textLength = strlen(text);
+  unsigned char *data = malloc(((textLength / 4) + 1) * 3 + 1);
+  if (!data) return NULL;
+
+  size_t outLength = 0;
+  int quad[4];
+  unsigned int quadCount = 0;
+
+  for (size_t i=0; i<textLength; i+=1) {
+    if (text[i] == '=') break;
+
+    int value = base64Value(text[i]);
+    if (value < 0) continue; /* skip whitespace and stray bytes */
+
+    quad[quadCount++] = value;
+    if (quadCount == 4) {
+      data[outLength++] = (quad[0] << 2) | (quad[1] >> 4);
+      data[outLength++] = (quad[1] << 4) | (quad[2] >> 2);
+      data[outLength++] = (quad[2] << 6) | quad[3];
+      quadCount = 0;
+    }
+  }
+
+  if (quadCount >= 2) {
+    data[outLength++] = (quad[0] << 2) | (quad[1] >> 4);
+    if (quadCount >= 3) data[outLength++] = (quad[1] << 4) | (quad[2] >> 2);
+  }
+
+  *length = outLength;
+  return data;
+}
+
+static void
+handleClipboardRequest (char *payload) {
+  /* payload is "<targets>;<data>" (the part after "52;"). */
+  char *data = strchr(payload, ';');
+  if (!data) return;
+  data += 1;
+
+  /* "?" is a read request; decline it so a program can't read the user's
+   * clipboard (a well-known OSC 52 privacy concern). */
+  if (strcmp(data, "?") == 0) return;
+
+  size_t length;
+  unsigned char *bytes = decodeBase64(data, &length);
+
+  if (bytes) {
+    if (length > 0) ptySetSystemClipboard((const char *)bytes, length);
+    free(bytes);
+  }
+}
+
+static void
+handleOscString (void) {
+  if (oscOverflow) return;
+  oscBuffer[oscLength] = 0;
+
+  if (strncmp(oscBuffer, "52;", 3) == 0) {
+    logOutputAction("osc52", "clipboard");
+    handleClipboardRequest(oscBuffer + 3);
+  }
+}
+
+static void
+finishStringControl (void) {
+  if (outputStringIsOsc) {
+    handleOscString();
+    outputStringIsOsc = 0;
+  }
+}
+
+static OutputByteParserResult
+parseOutputByte_STRING (unsigned char byte) {
+  switch (byte) {
+    case ASCII_BEL: /* OSC-style string terminator */
+      finishStringControl();
+      return OBP_DONE;
+
+    case ASCII_CAN: /* cancel - abort the string without acting on it */
+    case ASCII_SUB:
+      outputStringIsOsc = 0;
+      return OBP_DONE;
+
+    case ASCII_ESC: /* possible start of ST (ESC \) */
+      outputParserState = OPS_STRING_ESCAPE;
+      return OBP_CONTINUE;
+
+    default: /* consume the string payload */
+      if (outputStringIsOsc) appendOscByte(byte);
+      return OBP_CONTINUE;
+  }
+}
+
+static OutputByteParserResult
+parseOutputByte_STRING_ESCAPE (unsigned char byte) {
+  if (byte == '\\') { /* ST - end of string */
+    finishStringControl();
+    return OBP_DONE;
+  }
+
+  /* Not a string terminator after all - stay within the string.
+   * Reprocess this byte so another ESC can still introduce an ST.
+   */
+  outputParserState = OPS_STRING;
+  return OBP_REPROCESS;
+}
+
+static OutputByteParserResult
 parseOutputByte_BRACKET (unsigned char byte) {
   outputParserState = OPS_NUMBER;
   if (outputParserQuestionMark) return OBP_REPROCESS;
-  if (byte != '?') return OBP_REPROCESS;
 
-  outputParserQuestionMark = 1;
-  outputParserState = OPS_BRACKET;
-  return OBP_CONTINUE;
+  switch (byte) {
+    case '?':
+      outputParserQuestionMark = 1;
+      outputParserState = OPS_BRACKET;
+      return OBP_CONTINUE;
+
+    case '>': /* secondary device attributes (and kitty keyboard) marker */
+      outputParserGreaterThan = 1;
+      return OBP_CONTINUE;
+
+    case '=': /* tertiary DA / other private parameter markers. We don't */
+    case '<': /* implement these, but consume the marker so the rest of  */
+      return OBP_CONTINUE; /* the sequence is parsed and not leaked.      */
+  }
+
+  return OBP_REPROCESS;
 }
 
 static OutputByteParserResult
@@ -612,6 +1129,14 @@ performBracketAction_m (unsigned char byte) {
                   if (count >= 3) {
                     color = outputParserNumberArray[++index];
                     if (color <= 0XF) goto SET_COLOR;
+
+                    /* Map the rest of the 256-color palette (16-255) to the
+                     * nearest VGA color rather than rejecting it, which would
+                     * abort the whole SGR run and drop trailing attributes. */
+                    if (color <= 0XFF) {
+                      color = rgbColorToVga(ansiToRgb(color), 0);
+                      goto SET_COLOR;
+                    }
                   }
 
                   break;
@@ -796,11 +1321,30 @@ performBracketAction (unsigned char byte) {
       return OBP_DONE;
     }
 
-    case 'J':
-      if (outputParserNumberCount != 0) return OBP_UNEXPECTED;
-      logOutputAction("ed", "clear to end of display");
-      ptyClearToEndOfDisplay();
-      return OBP_DONE;
+    case 'J': {
+      if (outputParserNumberCount == 0) addOutputParserNumber(0);
+      if (outputParserNumberCount != 1) return OBP_UNEXPECTED;
+
+      switch (outputParserNumberArray[0]) {
+        case 0:
+          logOutputAction("ed", "clear to end of display");
+          ptyClearToEndOfDisplay();
+          return OBP_DONE;
+
+        case 1:
+          logOutputAction("ed1", "clear to beginning of display");
+          ptyClearToBeginningOfDisplay();
+          return OBP_DONE;
+
+        case 3: /* clear scrollback - we keep none, so clear the screen */
+        case 2:
+          logOutputAction("ed2", "clear display");
+          ptyClearDisplay();
+          return OBP_DONE;
+      }
+
+      break;
+    }
 
     case 'K': {
       if (outputParserNumberCount == 0) addOutputParserNumber(0);
@@ -816,6 +1360,67 @@ performBracketAction (unsigned char byte) {
           logOutputAction("el1", "clear to beginning of line");
           ptyClearToBeginningOfLine();
           return OBP_DONE;
+
+        case 2:
+          logOutputAction("el2", "clear line");
+          ptyClearLine();
+          return OBP_DONE;
+      }
+
+      break;
+    }
+
+    case 'X':
+      logOutputAction("ech", "erase characters");
+      ptyEraseCharacters(getOutputActionCount());
+      return OBP_DONE;
+
+    case 'b':
+      logOutputAction("rep", "repeat last character");
+      for (unsigned int count=getOutputActionCount(); count>0; count-=1) {
+        addTextCharacter(lastTextCharacter);
+      }
+      return OBP_DONE;
+
+    case 'c': {
+      /* Device attributes: reply so a probing program doesn't stall. */
+      unsigned int parameter = outputParserNumberCount? outputParserNumberArray[0]: 0;
+      if (parameter != 0) return OBP_UNEXPECTED;
+
+      if (outputParserGreaterThan) {
+        logOutputAction("da2", "secondary device attributes");
+        sendDeviceResponse("\x1B[>0;0;0c");
+      } else {
+        logOutputAction("da", "primary device attributes");
+        sendDeviceResponse("\x1B[?1;2c");
+      }
+
+      return OBP_DONE;
+    }
+
+    case 'n': {
+      /* Device status report. */
+      if (outputParserNumberCount != 1) return OBP_UNEXPECTED;
+
+      switch (outputParserNumberArray[0]) {
+        case 5: /* "are you ok?" -> "I am ok" */
+          logOutputAction("dsr", "device status report");
+          sendDeviceResponse("\x1B[0n");
+          return OBP_DONE;
+
+        case 6: { /* report cursor position (CPR) */
+          unsigned int row, column;
+          ptyGetCursorPosition(&row, &column);
+
+          char response[0X20];
+          STR_BEGIN(response, sizeof(response));
+          STR_PRINTF("\x1B[%u;%uR", (row + 1), (column + 1));
+          STR_END;
+
+          logOutputAction("cpr", "cursor position report");
+          sendDeviceResponse(response);
+          return OBP_DONE;
+        }
       }
 
       break;
@@ -868,7 +1473,17 @@ performBracketAction (unsigned char byte) {
       return performBracketAction_l(byte);
 
     case 'm':
+      /* "CSI > ... m" is XTMODKEYS (modifyOtherKeys) keyboard-protocol
+       * negotiation, not SGR. Swallow it rather than mistaking the parameters
+       * for graphic renditions (e.g. turning on underline/dim). */
+      if (outputParserGreaterThan) return OBP_DONE;
       return performBracketAction_m(byte);
+
+    case 'u':
+      /* "CSI ... u" is the kitty keyboard-protocol negotiation (push/pop/set
+       * the keyboard mode). We don't drive the host into those modes, so just
+       * consume it - it must never reach the screen as text. */
+      return OBP_DONE;
 
     case 'r': {
       if (outputParserNumberCount != 2) return OBP_UNEXPECTED;
@@ -898,8 +1513,8 @@ performQuestionMarkAction_h (unsigned char byte) {
   if (outputParserNumberCount == 1) {
     switch (outputParserNumberArray[0]) {
       case 1:
-        logOutputAction("smkx", "keypad transmit on");
-        keypadTransmitMode = 1;
+        logOutputAction("DECCKM", "application cursor keys on");
+        cursorKeyMode = 1;
         return OBP_DONE;
 
       case 25:
@@ -910,6 +1525,13 @@ performQuestionMarkAction_h (unsigned char byte) {
       case 1049:
         logOutputAction("smcup", "absolute cursor addressing on");
         absoluteCursorAddressingMode = 1;
+        /* Entering the alternate screen presents a cleared buffer (this is
+         * what xterm's ?1049 does). We have only one buffer, so emulate it by
+         * saving the cursor and clearing the screen; otherwise a full-screen
+         * program (e.g. Claude Code) draws on top of the previous contents. */
+        ptySaveCursorPosition();
+        ptySetCursorPosition(0, 0);
+        ptyClearToEndOfDisplay();
         return OBP_DONE;
 
       case 2004:
@@ -927,8 +1549,8 @@ performQuestionMarkAction_l (unsigned char byte) {
   if (outputParserNumberCount == 1) {
     switch (outputParserNumberArray[0]) {
       case 1:
-        logOutputAction("rmkx", "keypad transmit off");
-        keypadTransmitMode = 0;
+        logOutputAction("DECCKM", "application cursor keys off");
+        cursorKeyMode = 0;
         return OBP_DONE;
 
       case 25:
@@ -939,6 +1561,13 @@ performQuestionMarkAction_l (unsigned char byte) {
       case 1049:
         logOutputAction("rmcup", "absolute cursor addressing off");
         absoluteCursorAddressingMode = 0;
+        /* Leaving the alternate screen would normally restore the primary
+         * screen. We can't restore it (single buffer), but we must not leave
+         * the full-screen program's last frame behind as stale text; clear it
+         * and put the cursor back where it was before smcup. */
+        ptySetCursorPosition(0, 0);
+        ptyClearToEndOfDisplay();
+        ptyRestoreCursorPosition();
         return OBP_DONE;
 
       case 2004:
@@ -966,6 +1595,14 @@ performQuestionMarkAction (unsigned char byte) {
 
 static OutputByteParserResult
 parseOutputByte_ACTION (unsigned char byte) {
+  if ((byte >= 0X20) && (byte <= 0X2F)) {
+    /* CSI intermediate byte (e.g. the space in "\e[5 q" to set the
+     * cursor shape). Consume it and wait for the final byte so the
+     * whole sequence is swallowed as a unit rather than leaking.
+     */
+    return OBP_CONTINUE;
+  }
+
   if (outputParserQuestionMark) {
     return performQuestionMarkAction(byte);
   } else {
@@ -991,6 +1628,10 @@ static const OutputParserStateEntry outputParserStateTable[] = {
   OPS(NUMBER),
   OPS(DIGIT),
   OPS(ACTION),
+  OPS(STRING),
+  OPS(STRING_ESCAPE),
+  OPS(DISCARD),
+  OPS(TEXT),
 };
 #undef OPS
 

--- a/Programs/ptyclip.c
+++ b/Programs/ptyclip.c
@@ -1,0 +1,356 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+/* End-to-end test for brltty-pty's clipboard bridge (emulator side).
+ *
+ * Each scenario launches the real brltty-pty (with --driver-directives, so the
+ * terminal message queue is active) and stands in for both the outer terminal
+ * (it owns the master pty) and the screen driver (it attaches to the message
+ * queue). It drives BRLTTY's clipboard out to the host via
+ * TERM_MSG_CLIPBOARD_TO_HOST and checks the two publish modes:
+ *   - native:      BRLTTY_PTY_CLIPBOARD_FILE intercepts the write; expect the
+ *                  file to hold the text. (No real pasteboard is touched.)
+ *   - passthrough: BRLTTY_PTY_CLIPBOARD_MODE=passthrough; expect an OSC 52
+ *                  sequence carrying the base64 text on the outer pty.
+ *
+ * Exits 77 ("skipped") when the environment can't support the setup.
+ */
+
+#include "prologue.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <sys/msg.h>
+
+#include "cmdline.h"
+#include "scr_terminal.h"
+#include "msg_queue.h"
+
+#define SKIP_STATUS 77
+#define CLIPBOARD_TEXT "from-brltty-clipboard"
+
+BEGIN_COMMAND_LINE_OPTIONS(programOptions)
+END_COMMAND_LINE_OPTIONS(programOptions)
+
+BEGIN_COMMAND_LINE_PARAMETERS(programParameters)
+END_COMMAND_LINE_PARAMETERS(programParameters)
+
+BEGIN_COMMAND_LINE_NOTES(programNotes)
+END_COMMAND_LINE_NOTES
+
+BEGIN_COMMAND_LINE_DESCRIPTOR(programDescriptor)
+  .name = "ptyclip",
+  .purpose = strtext("Test brltty-pty's clipboard bridge end to end."),
+
+  .options = &programOptions,
+  .parameters = &programParameters,
+  .notes = COMMAND_LINE_NOTES(programNotes),
+END_COMMAND_LINE_DESCRIPTOR
+
+static long
+nowMilliseconds (void) {
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  return ((long)now.tv_sec * 1000) + (now.tv_usec / 1000);
+}
+
+/* Search a (possibly binary) buffer for a NUL-terminated needle. */
+static int
+bufferContains (const char *haystack, size_t length, const char *needle) {
+  size_t needleLength = strlen(needle);
+  if (needleLength == 0 || length < needleLength) return 0;
+
+  for (size_t i=0; i+needleLength<=length; i+=1) {
+    if (memcmp(haystack + i, needle, needleLength) == 0) return 1;
+  }
+
+  return 0;
+}
+
+static int
+readFileEquals (const char *path, const char *expected) {
+  FILE *file = fopen(path, "r");
+  if (!file) return 0;
+
+  char buffer[0X100] = {0};
+  size_t length = fread(buffer, 1, sizeof(buffer) - 1, file);
+  fclose(file);
+  buffer[length] = 0;
+
+  return strcmp(buffer, expected) == 0;
+}
+
+static const char base64Alphabet[] =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/* Encode for the passthrough expectation; mirrors encodeBase64 in pty_clipboard.c. */
+static void
+encodeBase64 (const char *text, char *out) {
+  const unsigned char *data = (const unsigned char *)text;
+  size_t length = strlen(text);
+  size_t in = 0, off = 0;
+
+  while ((length - in) >= 3) {
+    unsigned int triple = (data[in] << 16) | (data[in+1] << 8) | data[in+2];
+    out[off++] = base64Alphabet[(triple >> 18) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 12) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 6) & 0X3F];
+    out[off++] = base64Alphabet[triple & 0X3F];
+    in += 3;
+  }
+
+  size_t remaining = length - in;
+  if (remaining == 1) {
+    unsigned int triple = data[in] << 16;
+    out[off++] = base64Alphabet[(triple >> 18) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 12) & 0X3F];
+    out[off++] = '='; out[off++] = '=';
+  } else if (remaining == 2) {
+    unsigned int triple = (data[in] << 16) | (data[in+1] << 8);
+    out[off++] = base64Alphabet[(triple >> 18) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 12) & 0X3F];
+    out[off++] = base64Alphabet[(triple >> 6) & 0X3F];
+    out[off++] = '=';
+  }
+
+  out[off] = 0;
+}
+
+/* Run one publish scenario. passthrough selects the mode; returns PROG_EXIT_*
+ * or SKIP_STATUS. */
+static int
+runScenario (int passthrough, const char *label) {
+  char setPath[0X100];
+  snprintf(setPath, sizeof(setPath), "/tmp/ptyclip.%d.%d", passthrough, (int)getpid());
+  unlink(setPath);
+
+  int master = posix_openpt(O_RDWR | O_NOCTTY);
+  if (master == -1) return SKIP_STATUS;
+  if ((grantpt(master) == -1) || (unlockpt(master) == -1)) { close(master); return SKIP_STATUS; }
+
+  char slavePath[0X100];
+  {
+    const char *name = ptsname(master);
+    if (!name) { close(master); return SKIP_STATUS; }
+    snprintf(slavePath, sizeof(slavePath), "%s", name);
+  }
+
+  int sizedSlave = open(slavePath, O_RDWR);
+  {
+    struct winsize size = { .ws_row = 24, .ws_col = 80 };
+    ioctl((sizedSlave != -1)? sizedSlave: master, TIOCSWINSZ, &size);
+  }
+
+  int errorPipe[2];
+  if (pipe(errorPipe) == -1) { close(master); if (sizedSlave != -1) close(sizedSlave); return SKIP_STATUS; }
+
+  pid_t child = fork();
+  if (child == -1) {
+    close(master); if (sizedSlave != -1) close(sizedSlave);
+    close(errorPipe[0]); close(errorPipe[1]);
+    return SKIP_STATUS;
+  }
+
+  if (child == 0) {
+    setsid();
+    int slave = open(slavePath, O_RDWR);
+    if (slave == -1) _exit(SKIP_STATUS);
+#ifdef TIOCSCTTY
+    ioctl(slave, TIOCSCTTY, 0);
+#endif
+    dup2(slave, STDIN_FILENO);
+    dup2(slave, STDOUT_FILENO);
+    dup2(errorPipe[1], STDERR_FILENO);
+    close(master);
+    if (sizedSlave != -1) close(sizedSlave);
+    close(errorPipe[0]);
+    close(errorPipe[1]);
+    if (slave > STDERR_FILENO) close(slave);
+
+    setenv("TERM", "xterm-256color", 1);
+    if (passthrough) {
+      setenv("BRLTTY_PTY_CLIPBOARD_MODE", "passthrough", 1);
+    } else {
+      /* The write-file override intercepts before the mode, so this exercises
+       * the publish plumbing without a real pasteboard regardless of mode. */
+      setenv("BRLTTY_PTY_CLIPBOARD_FILE", setPath, 1);
+    }
+
+    /* --driver-directives enables the message queue and prints the inner pty
+     * path to stderr. */
+    execl("./brltty-pty", "brltty-pty", "--driver-directives",
+          "sh", "-c", "sleep 30", (char *)NULL);
+    _exit(SKIP_STATUS);
+  }
+
+  close(errorPipe[1]);
+  fcntl(master, F_SETFL, O_NONBLOCK);
+  fcntl(errorPipe[0], F_SETFL, O_NONBLOCK);
+
+  int result = SKIP_STATUS;
+
+  /* Accumulate everything the emulator writes to the outer pty, so a passthrough
+   * OSC 52 can be found in it. */
+  char outBuffer[0X4000];
+  size_t outLength = 0;
+
+  char ptyPath[0X100] = {0};
+  char errorText[0X1000];
+  size_t errorLength = 0;
+  const long deadline = nowMilliseconds() + 8000;
+
+  /* Learn the inner pty path from the "path ..." driver directive. */
+  while (!*ptyPath && (nowMilliseconds() < deadline)) {
+    if (outLength < sizeof(outBuffer) - 1) {
+      ssize_t n = read(master, outBuffer + outLength, sizeof(outBuffer) - 1 - outLength);
+      if (n > 0) outLength += n;
+    }
+
+    struct pollfd pfd = { .fd = errorPipe[0], .events = POLLIN };
+    poll(&pfd, 1, 50);
+    ssize_t count = read(errorPipe[0], errorText + errorLength, sizeof(errorText) - errorLength - 1);
+    if (count > 0) {
+      errorLength += count;
+      errorText[errorLength] = 0;
+      char *line = errorText, *newline;
+      while ((newline = strchr(line, '\n'))) {
+        *newline = 0;
+        char *slash = strchr(line, '/');
+        if (slash) { snprintf(ptyPath, sizeof(ptyPath), "%s", slash); break; }
+        line = newline + 1;
+      }
+    }
+  }
+
+  if (!*ptyPath) {
+    fprintf(stderr, "  SKIP %s: brltty-pty did not start (likely sandboxed)\n", label);
+    goto cleanup;
+  }
+
+  key_t key;
+  int queue;
+  if (!makeTerminalKey(&key, ptyPath) || !getMessageQueue(&queue, key)) {
+    fprintf(stderr, "  SKIP %s: message queue unavailable\n", label);
+    goto cleanup;
+  }
+
+  result = PROG_EXIT_SUCCESS;
+
+  /* Send BRLTTY's clipboard; the emulator must publish it to the host. */
+  sendMessage(queue, TERM_MSG_CLIPBOARD_TO_HOST, CLIPBOARD_TEXT, strlen(CLIPBOARD_TEXT), 0);
+
+  char expectedOsc[0X100];
+  if (passthrough) {
+    char encoded[0X80];
+    encodeBase64(CLIPBOARD_TEXT, encoded);
+    snprintf(expectedOsc, sizeof(expectedOsc), "\033]52;c;%s", encoded);
+  }
+
+  int ok = 0;
+  const long settle = nowMilliseconds() + 3000;
+  while (nowMilliseconds() < settle) {
+    if (outLength < sizeof(outBuffer) - 1) {
+      ssize_t n = read(master, outBuffer + outLength, sizeof(outBuffer) - 1 - outLength);
+      if (n > 0) outLength += n;
+    }
+
+    if (passthrough) {
+      if (bufferContains(outBuffer, outLength, expectedOsc)) { ok = 1; break; }
+    } else if (readFileEquals(setPath, CLIPBOARD_TEXT)) {
+      ok = 1; break;
+    }
+
+    usleep(50000);
+  }
+
+  if (ok) {
+    fprintf(stderr, "  ok   %s: clipboard reached the host\n", label);
+  } else {
+    fprintf(stderr, "  FAIL %s: clipboard not published\n", label);
+    result = PROG_EXIT_FATAL;
+  }
+
+cleanup:
+  if (child > 0) {
+    kill(child, SIGTERM);
+    int reaped = 0;
+    for (int i=0; i<20; i+=1) {
+      char scratch[0X400];
+      while (read(master, scratch, sizeof(scratch)) > 0);
+      if (waitpid(child, NULL, WNOHANG) == child) { reaped = 1; break; }
+      usleep(50000);
+    }
+    if (!reaped) { kill(child, SIGKILL); waitpid(child, NULL, 0); }
+  }
+
+  if (*ptyPath) {
+    /* brltty-pty's shared-memory segment and its message queue share one key
+     * (ftok(path,'t')); remove both so a SIGKILLed brltty-pty doesn't leak them. */
+    key_t key2 = ftok(ptyPath, 't');
+    if (key2 != -1) {
+      int id = shmget(key2, 0, 0);
+      if (id != -1) shmctl(id, IPC_RMID, NULL);
+
+      int queue = msgget(key2, 0);
+      if (queue != -1) msgctl(queue, IPC_RMID, NULL);
+    }
+  }
+
+  unlink(setPath);
+  if (sizedSlave != -1) close(sizedSlave);
+  close(master);
+  close(errorPipe[0]);
+  return result;
+}
+
+int
+main (int argc, char *argv[]) {
+  PROCESS_COMMAND_LINE(programDescriptor, argc, argv);
+
+  int failures = 0;
+  int ran = 0;
+
+  static const struct { int passthrough; const char *label; } scenarios[] = {
+    { .passthrough = 0, .label = "native (file)" },
+    { .passthrough = 1, .label = "passthrough (OSC 52)" },
+  };
+
+  for (unsigned int i=0; i<ARRAY_COUNT(scenarios); i+=1) {
+    int status = runScenario(scenarios[i].passthrough, scenarios[i].label);
+    if (status == PROG_EXIT_SUCCESS) ran += 1;
+    else if (status != SKIP_STATUS) failures += 1;
+  }
+
+  int result = failures? PROG_EXIT_FATAL: ran? PROG_EXIT_SUCCESS: SKIP_STATUS;
+
+  fprintf(stderr, "\nclipboard bridge: %s\n",
+          (result == PROG_EXIT_SUCCESS)? "all checks passed":
+          (result == SKIP_STATUS)? "skipped": "FAILED");
+  return result;
+}

--- a/Programs/ptydump.c
+++ b/Programs/ptydump.c
@@ -1,0 +1,235 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+/* Debug helper: render a raw byte stream through the real brltty-pty terminal
+ * emulator and print the resulting screen grid (as UTF-8) plus the cursor
+ * position. Useful for reproducing and diagnosing rendering problems.
+ *
+ * Configuration is via the environment so it does not fight the command-line
+ * parser:
+ *   PTYDUMP_INPUT  absolute path to a file whose bytes are fed to the emulator
+ *   PTYDUMP_ROWS   screen height (default 24)
+ *   PTYDUMP_COLS   screen width  (default 80)
+ */
+
+#include "prologue.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include "cmdline.h"
+#include "scr_terminal.h"
+#include "utf8.h"
+
+#define SKIP_STATUS 77
+
+BEGIN_COMMAND_LINE_OPTIONS(programOptions)
+END_COMMAND_LINE_OPTIONS(programOptions)
+
+BEGIN_COMMAND_LINE_PARAMETERS(programParameters)
+END_COMMAND_LINE_PARAMETERS(programParameters)
+
+BEGIN_COMMAND_LINE_NOTES(programNotes)
+END_COMMAND_LINE_NOTES
+
+BEGIN_COMMAND_LINE_DESCRIPTOR(programDescriptor)
+  .name = "ptydump",
+  .purpose = strtext("Render a byte stream through brltty-pty and print the screen grid."),
+
+  .options = &programOptions,
+  .parameters = &programParameters,
+  .notes = COMMAND_LINE_NOTES(programNotes),
+END_COMMAND_LINE_DESCRIPTOR
+
+static long
+nowMilliseconds (void) {
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  return ((long)now.tv_sec * 1000) + (now.tv_usec / 1000);
+}
+
+static void
+drain (int fd) {
+  char buffer[0X400];
+  while (read(fd, buffer, sizeof(buffer)) > 0);
+}
+
+static void
+dumpScreen (ScreenSegmentHeader *segment) {
+  unsigned int rows = segment->screenHeight;
+  unsigned int cols = segment->screenWidth;
+
+  fprintf(stderr, "screen %ux%u cursor=(row %u, col %u)\n",
+          cols, rows, segment->cursorRow, segment->cursorColumn);
+
+  fprintf(stderr, "    +");
+  for (unsigned int c=0; c<cols; c+=1) fprintf(stderr, "-");
+  fprintf(stderr, "+\n");
+
+  for (unsigned int r=0; r<rows; r+=1) {
+    fprintf(stderr, "%3u |", r);
+
+    for (unsigned int c=0; c<cols; c+=1) {
+      const ScreenSegmentCharacter *cell = getScreenCharacter(segment, r, c, NULL);
+      uint32_t text = cell? cell->text: ' ';
+      if ((text == 0) || (text == ' ')) {
+        fputc(' ', stderr);
+      } else {
+        Utf8Buffer utf8;
+        size_t length = convertCodepointToUtf8(text, utf8);
+        fwrite(utf8, 1, length, stderr);
+      }
+    }
+
+    fprintf(stderr, "|%s\n", (r == segment->cursorRow)? " <-- cursor row": "");
+  }
+
+  fprintf(stderr, "    +");
+  for (unsigned int c=0; c<cols; c+=1) fprintf(stderr, "-");
+  fprintf(stderr, "+\n");
+}
+
+int
+main (int argc, char *argv[]) {
+  PROCESS_COMMAND_LINE(programDescriptor, argc, argv);
+
+  const char *inputPath = getenv("PTYDUMP_INPUT");
+  if (!inputPath || !*inputPath) {
+    fprintf(stderr, "ptydump: set PTYDUMP_INPUT to a file of bytes to render\n");
+    return PROG_EXIT_SYNTAX;
+  }
+
+  unsigned short rows = 24;
+  unsigned short cols = 80;
+  { const char *v = getenv("PTYDUMP_ROWS"); if (v && atoi(v) > 0) rows = atoi(v); }
+  { const char *v = getenv("PTYDUMP_COLS"); if (v && atoi(v) > 0) cols = atoi(v); }
+
+  int master = posix_openpt(O_RDWR | O_NOCTTY);
+  if (master == -1) { fprintf(stderr, "posix_openpt: %s\n", strerror(errno)); return SKIP_STATUS; }
+  if ((grantpt(master) == -1) || (unlockpt(master) == -1)) return SKIP_STATUS;
+
+  char slavePath[0X100];
+  { const char *n = ptsname(master); if (!n) return SKIP_STATUS; snprintf(slavePath, sizeof(slavePath), "%s", n); }
+
+  /* On macOS a pty's window size is only retained while a slave fd is open,
+   * and setting it on the master before any slave exists is silently ignored.
+   * Open a slave here, set the size on it, and keep it open for the lifetime
+   * of the test so brltty-pty sees a properly sized controlling terminal. */
+  int sizedSlave = open(slavePath, O_RDWR);
+  if (sizedSlave != -1) {
+    struct winsize ws = { .ws_row = rows, .ws_col = cols };
+    ioctl(sizedSlave, TIOCSWINSZ, &ws);
+  }
+
+  int errorPipe[2];
+  if (pipe(errorPipe) == -1) return SKIP_STATUS;
+
+  char command[0X400];
+  snprintf(command, sizeof(command), "cat '%s'; sleep 30", inputPath);
+
+  pid_t child = fork();
+  if (child == -1) return SKIP_STATUS;
+
+  if (child == 0) {
+    setsid();
+    int slave = open(slavePath, O_RDWR);
+    if (slave == -1) _exit(SKIP_STATUS);
+#ifdef TIOCSCTTY
+    ioctl(slave, TIOCSCTTY, 0);
+#endif
+    dup2(slave, STDIN_FILENO);
+    dup2(slave, STDOUT_FILENO);
+    dup2(errorPipe[1], STDERR_FILENO);
+    close(master); close(errorPipe[0]); close(errorPipe[1]);
+    if (slave > STDERR_FILENO) close(slave);
+    setenv("TERM", "xterm-256color", 1);
+    execl("./brltty-pty", "brltty-pty", "--show-path", "sh", "-c", command, (char *)NULL);
+    _exit(SKIP_STATUS);
+  }
+
+  close(errorPipe[1]);
+  fcntl(master, F_SETFL, O_NONBLOCK);
+  fcntl(errorPipe[0], F_SETFL, O_NONBLOCK);
+
+  int exitStatus = SKIP_STATUS;
+  ScreenSegmentHeader *segment = NULL;
+  char ptyPath[0X100] = {0};
+  char errorText[0X1000];
+  size_t errorLength = 0;
+  const long deadline = nowMilliseconds() + 12000;
+
+  while (!*ptyPath && (nowMilliseconds() < deadline)) {
+    drain(master);
+    struct pollfd pfd = { .fd = errorPipe[0], .events = POLLIN };
+    poll(&pfd, 1, 50);
+    ssize_t count = read(errorPipe[0], errorText + errorLength, sizeof(errorText) - errorLength - 1);
+    if (count > 0) {
+      errorLength += count;
+      errorText[errorLength] = 0;
+      char *line = errorText, *nl;
+      while ((nl = strchr(line, '\n'))) {
+        *nl = 0;
+        if (line[0] == '/') { snprintf(ptyPath, sizeof(ptyPath), "%s", line); break; }
+        line = nl + 1;
+      }
+    }
+  }
+
+  if (!*ptyPath) { fprintf(stderr, "SKIP: brltty-pty did not start\n"); goto cleanup; }
+
+  while (!segment && (nowMilliseconds() < deadline)) {
+    drain(master);
+    segment = getScreenSegmentForPath(ptyPath);
+    if (!segment) usleep(50000);
+  }
+  if (!segment) { fprintf(stderr, "SKIP: segment unavailable\n"); goto cleanup; }
+
+  /* Give the emulator time to consume all of the input. */
+  for (int i=0; i<10; i+=1) { drain(master); usleep(50000); }
+
+  dumpScreen(segment);
+  exitStatus = PROG_EXIT_SUCCESS;
+
+cleanup:
+  if (sizedSlave != -1) close(sizedSlave);
+  if (segment) detachScreenSegment(segment);
+  if (child > 0) {
+    kill(child, SIGTERM);
+    int reaped = 0;
+    for (int i=0; i<20; i+=1) { drain(master); if (waitpid(child, NULL, WNOHANG) == child) { reaped = 1; break; } usleep(50000); }
+    if (!reaped) { kill(child, SIGKILL); waitpid(child, NULL, 0); }
+  }
+  if (*ptyPath) {
+    key_t key = ftok(ptyPath, 't');
+    if (key != -1) { int id = shmget(key, 0, 0); if (id != -1) shmctl(id, IPC_RMID, NULL); }
+  }
+  close(master);
+  close(errorPipe[0]);
+  return exitStatus;
+}

--- a/Programs/ptyinput.c
+++ b/Programs/ptyinput.c
@@ -1,0 +1,400 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+/* End-to-end test for brltty-pty's keyboard input translation.
+ *
+ * It launches the real brltty-pty on its own pseudo-terminal, has it run a
+ * child (this same binary, in "reader" mode) that puts its terminal into raw
+ * mode and copies every byte it receives to a file. The test then writes a
+ * key sequence (as a host terminal would) to brltty-pty's controlling terminal
+ * and checks that the child received the bytes a screen/tmux program expects.
+ *
+ * This is how we verify, for example, that Home arriving as the application
+ * sequence "ESC O H" is delivered to the child as "ESC [ 1 ~" (and not left as
+ * "ESC O H", which vim would read as "open line and insert").
+ *
+ * Because it depends on pseudo-terminal allocation, it exits with status 77
+ * (the conventional "skipped" code) when the environment cannot support it.
+ */
+
+#include "prologue.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include "cmdline.h"
+
+#define SKIP_STATUS 77
+
+BEGIN_COMMAND_LINE_OPTIONS(programOptions)
+END_COMMAND_LINE_OPTIONS(programOptions)
+
+BEGIN_COMMAND_LINE_PARAMETERS(programParameters)
+END_COMMAND_LINE_PARAMETERS(programParameters)
+
+BEGIN_COMMAND_LINE_NOTES(programNotes)
+END_COMMAND_LINE_NOTES
+
+BEGIN_COMMAND_LINE_DESCRIPTOR(programDescriptor)
+  .name = "ptyinput",
+  .purpose = strtext("Test brltty-pty keyboard input translation end to end."),
+
+  .options = &programOptions,
+  .parameters = &programParameters,
+  .notes = COMMAND_LINE_NOTES(programNotes),
+END_COMMAND_LINE_DESCRIPTOR
+
+/* The environment variables that put this binary into "reader" (child) mode. */
+#define ENV_OUTPUT "PTYINPUT_OUTPUT"   /* file to append received bytes to     */
+#define ENV_INIT   "PTYINPUT_INIT"     /* bytes to emit to stdout at startup    */
+
+/* Reader mode: become the program running inside brltty-pty. Optionally emit an
+ * initialization sequence to the emulator (e.g. smkx to turn on application
+ * cursor keys), then copy raw stdin to the output file a byte at a time. */
+static int
+runReader (void) {
+  const char *outputPath = getenv(ENV_OUTPUT);
+  if (!outputPath) return SKIP_STATUS;
+
+  {
+    struct termios attributes;
+    if (tcgetattr(STDIN_FILENO, &attributes) != -1) {
+      cfmakeraw(&attributes);
+      tcsetattr(STDIN_FILENO, TCSANOW, &attributes);
+    }
+  }
+
+  {
+    const char *init = getenv(ENV_INIT);
+    if (init && *init) {
+      write(STDOUT_FILENO, init, strlen(init));
+    }
+  }
+
+  int output = open(outputPath, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  if (output == -1) return SKIP_STATUS;
+
+  while (1) {
+    char byte;
+    ssize_t count = read(STDIN_FILENO, &byte, 1);
+    if (count <= 0) break;
+    write(output, &byte, 1);
+    fsync(output);
+  }
+
+  close(output);
+  return PROG_EXIT_SUCCESS;
+}
+
+typedef struct {
+  const char *name;
+  const char *init;          /* bytes the child emits first (NULL for none) */
+  const unsigned char *input;
+  size_t inputLength;
+  const unsigned char *expected;
+  size_t expectedLength;
+} Scenario;
+
+#define BYTES(...) (const unsigned char []){__VA_ARGS__}, sizeof((const unsigned char []){__VA_ARGS__})
+
+static const Scenario scenarios[] = {
+  { .name = "plain text passes through",
+    .input = BYTES('h','i'), .expected = BYTES('h','i') },
+
+  { .name = "UTF-8 passes through",                       /* e-acute */
+    .input = BYTES(0xC3,0xA9), .expected = BYTES(0xC3,0xA9) },
+
+  { .name = "Alt+a stays ESC a",
+    .input = BYTES(0x1B,'a'), .expected = BYTES(0x1B,'a') },
+
+  { .name = "Home (SS3 ESC O H) -> ESC [ 1 ~",
+    .input = BYTES(0x1B,'O','H'), .expected = BYTES(0x1B,'[','1','~') },
+
+  { .name = "End (SS3 ESC O F) -> ESC [ 4 ~",
+    .input = BYTES(0x1B,'O','F'), .expected = BYTES(0x1B,'[','4','~') },
+
+  { .name = "Home (tilde) stays ESC [ 1 ~",
+    .input = BYTES(0x1B,'[','1','~'), .expected = BYTES(0x1B,'[','1','~') },
+
+  { .name = "Up arrow, normal mode -> ESC [ A",
+    .input = BYTES(0x1B,'[','A'), .expected = BYTES(0x1B,'[','A') },
+
+  { .name = "Up arrow, application mode -> ESC O A",
+    .init = "\x1B[?1h",
+    .input = BYTES(0x1B,'[','A'), .expected = BYTES(0x1B,'O','A') },
+
+  { .name = "Ctrl+Left passes through ESC [ 1 ; 5 D",
+    .input = BYTES(0x1B,'[','1',';','5','D'), .expected = BYTES(0x1B,'[','1',';','5','D') },
+
+  { .name = "lone ESC becomes Escape after timeout",
+    .input = BYTES(0x1B), .expected = BYTES(0x1B) },
+
+  /* Device queries: the child (init) emits the query to the emulator, which
+   * must reply on the child's input. No host input is sent. */
+  { .name = "primary device attributes (CSI c) answered",
+    .init = "\x1B[c",
+    .expected = BYTES(0x1B,'[','?','1',';','2','c') },
+
+  { .name = "cursor position report (CSI 6n) answered",
+    .init = "\x1B[6n",
+    .expected = BYTES(0x1B,'[','1',';','1','R') },
+};
+
+static long
+nowMilliseconds (void) {
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  return ((long)now.tv_sec * 1000) + (now.tv_usec / 1000);
+}
+
+static void
+drain (int fd) {
+  char buffer[0X400];
+  while (read(fd, buffer, sizeof(buffer)) > 0);
+}
+
+static void
+describeBytes (const char *label, const unsigned char *bytes, size_t length) {
+  fprintf(stderr, "    %s:", label);
+  for (size_t i=0; i<length; i+=1) fprintf(stderr, " %02X", bytes[i]);
+  fprintf(stderr, "\n");
+}
+
+static int
+runScenario (const Scenario *scenario, const char *selfPath) {
+  fprintf(stderr, "\n== input scenario: %s ==\n", scenario->name);
+
+  char outputPath[0X100];
+  snprintf(outputPath, sizeof(outputPath), "/tmp/ptyinput.%d.bin", (int)getpid());
+  unlink(outputPath);
+
+  int master = posix_openpt(O_RDWR | O_NOCTTY);
+  if (master == -1) return SKIP_STATUS;
+  if ((grantpt(master) == -1) || (unlockpt(master) == -1)) { close(master); return SKIP_STATUS; }
+
+  char slavePath[0X100];
+  {
+    const char *name = ptsname(master);
+    if (!name) { close(master); return SKIP_STATUS; }
+    snprintf(slavePath, sizeof(slavePath), "%s", name);
+  }
+
+  /* Keep a sized slave open: on macOS a pty's size is only retained while a
+   * slave fd is open. */
+  int sizedSlave = open(slavePath, O_RDWR);
+  {
+    struct winsize size = { .ws_row = 24, .ws_col = 80 };
+    ioctl((sizedSlave != -1)? sizedSlave: master, TIOCSWINSZ, &size);
+  }
+
+  /* brltty-pty prints its inner pty path on stderr (--show-path); capture it so
+   * we can remove the published shared-memory segment if brltty-pty is killed
+   * before it can clean up itself. */
+  int errorPipe[2];
+  if (pipe(errorPipe) == -1) { close(master); if (sizedSlave != -1) close(sizedSlave); return SKIP_STATUS; }
+
+  pid_t child = fork();
+  if (child == -1) {
+    close(master); if (sizedSlave != -1) close(sizedSlave);
+    close(errorPipe[0]); close(errorPipe[1]);
+    return SKIP_STATUS;
+  }
+
+  if (child == 0) {
+    setsid();
+    int slave = open(slavePath, O_RDWR);
+    if (slave == -1) _exit(SKIP_STATUS);
+#ifdef TIOCSCTTY
+    ioctl(slave, TIOCSCTTY, 0);
+#endif
+    dup2(slave, STDIN_FILENO);
+    dup2(slave, STDOUT_FILENO);
+    dup2(errorPipe[1], STDERR_FILENO);
+    close(master);
+    if (sizedSlave != -1) close(sizedSlave);
+    close(errorPipe[0]);
+    close(errorPipe[1]);
+    if (slave > STDERR_FILENO) close(slave);
+
+    setenv("TERM", "xterm-256color", 1);
+    setenv(ENV_OUTPUT, outputPath, 1);
+    if (scenario->init) setenv(ENV_INIT, scenario->init, 1);
+    else unsetenv(ENV_INIT);
+
+    execl("./brltty-pty", "brltty-pty", "--show-path", selfPath, (char *)NULL);
+    _exit(SKIP_STATUS);
+  }
+
+  close(errorPipe[1]);
+  fcntl(master, F_SETFL, O_NONBLOCK);
+  fcntl(errorPipe[0], F_SETFL, O_NONBLOCK);
+
+  int result = SKIP_STATUS;
+  char ptyPath[0X100] = {0};
+  char errorText[0X400];
+  size_t errorLength = 0;
+  const long deadline = nowMilliseconds() + 8000;
+
+  /* Wait for the child reader to create (and, with an init, write to) its
+   * output file, which means brltty-pty is up and the child is running. */
+  while (nowMilliseconds() < deadline) {
+    drain(master);
+
+    if (!*ptyPath) {
+      ssize_t count = read(errorPipe[0], errorText + errorLength,
+                           sizeof(errorText) - errorLength - 1);
+      if (count > 0) {
+        errorLength += count;
+        errorText[errorLength] = 0;
+        char *line = errorText, *newline;
+        while ((newline = strchr(line, '\n'))) {
+          *newline = 0;
+          if (line[0] == '/') { snprintf(ptyPath, sizeof(ptyPath), "%s", line); break; }
+          line = newline + 1;
+        }
+      }
+    }
+
+    if (access(outputPath, F_OK) == 0) break;
+    usleep(50000);
+  }
+
+  if (access(outputPath, F_OK) != 0) {
+    fprintf(stderr, "  SKIP: brltty-pty did not start (likely sandboxed)\n");
+    goto cleanup;
+  }
+
+  /* Let any initialization sequence reach and be processed by the emulator. */
+  if (scenario->init) {
+    for (int i=0; i<6; i+=1) { drain(master); usleep(50000); }
+  }
+
+  /* Send the key sequence as a host terminal would. */
+  {
+    size_t offset = 0;
+    while (offset < scenario->inputLength) {
+      ssize_t written = write(master, scenario->input + offset, scenario->inputLength - offset);
+      if (written > 0) offset += written;
+      else if ((errno == EAGAIN) || (errno == EINTR)) { drain(master); usleep(10000); }
+      else break;
+    }
+  }
+
+  /* Collect what the child received. Wait long enough to cover the lone-ESC
+   * timeout (100ms) plus scheduling slack. */
+  unsigned char got[0X40];
+  size_t gotLength = 0;
+  const long settle = nowMilliseconds() + 1500;
+  while (nowMilliseconds() < settle) {
+    drain(master);
+    int fd = open(outputPath, O_RDONLY);
+    if (fd != -1) {
+      gotLength = 0;
+      ssize_t n;
+      while ((gotLength < sizeof(got)) &&
+             ((n = read(fd, got + gotLength, sizeof(got) - gotLength)) > 0)) {
+        gotLength += n;
+      }
+      close(fd);
+    }
+    if (gotLength >= scenario->expectedLength) break;
+    usleep(30000);
+  }
+
+  if ((gotLength == scenario->expectedLength) &&
+      (memcmp(got, scenario->expected, gotLength) == 0)) {
+    fprintf(stderr, "  ok\n");
+    result = PROG_EXIT_SUCCESS;
+  } else {
+    fprintf(stderr, "  FAIL\n");
+    describeBytes("sent    ", scenario->input, scenario->inputLength);
+    describeBytes("expected", scenario->expected, scenario->expectedLength);
+    describeBytes("got     ", got, gotLength);
+    result = PROG_EXIT_FATAL;
+  }
+
+cleanup:
+  if (child > 0) {
+    kill(child, SIGTERM);
+    int reaped = 0;
+    for (int i=0; i<20; i+=1) {
+      drain(master);
+      if (waitpid(child, NULL, WNOHANG) == child) { reaped = 1; break; }
+      usleep(50000);
+    }
+    if (!reaped) { kill(child, SIGKILL); waitpid(child, NULL, 0); }
+  }
+
+  /* Remove the shared-memory segment in case brltty-pty was killed before it
+   * could clean up itself, so repeated runs never attach to a stale segment. */
+  if (*ptyPath) {
+    key_t key = ftok(ptyPath, 't');
+    if (key != -1) {
+      int identifier = shmget(key, 0, 0);
+      if (identifier != -1) shmctl(identifier, IPC_RMID, NULL);
+    }
+  }
+
+  unlink(outputPath);
+  if (sizedSlave != -1) close(sizedSlave);
+  close(master);
+  close(errorPipe[0]);
+  return result;
+}
+
+int
+main (int argc, char *argv[]) {
+  /* When brltty-pty runs us as its child, act as the raw-input reader. */
+  if (getenv(ENV_OUTPUT)) return runReader();
+
+  /* Resolve our own path before PROCESS_COMMAND_LINE, which rewrites argv. */
+  char selfPath[PATH_MAX];
+  if (!realpath(argv[0], selfPath)) {
+    snprintf(selfPath, sizeof(selfPath), "%s", argv[0]);
+  }
+
+  PROCESS_COMMAND_LINE(programDescriptor, argc, argv);
+
+  unsigned int failed = 0;
+  unsigned int skipped = 0;
+
+  for (unsigned int i=0; i<ARRAY_COUNT(scenarios); i+=1) {
+    int result = runScenario(&scenarios[i], selfPath);
+    if (result == PROG_EXIT_FATAL) failed += 1;
+    else if (result == SKIP_STATUS) skipped += 1;
+  }
+
+  fprintf(stderr, "\n%u input scenario(s): %u failed, %u skipped\n",
+          (unsigned int)ARRAY_COUNT(scenarios), failed, skipped);
+
+  if (failed) return PROG_EXIT_FATAL;
+  if (skipped == ARRAY_COUNT(scenarios)) return SKIP_STATUS;
+  return PROG_EXIT_SUCCESS;
+}

--- a/Programs/ptypass.c
+++ b/Programs/ptypass.c
@@ -1,0 +1,291 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+/* End-to-end test for brltty-pty's display passthrough (BRLTTY_PTY_PASSTHROUGH).
+ *
+ * It launches the real brltty-pty with passthrough enabled, running a child that
+ * emits a known mix of output, and stands in for the outer terminal (it owns the
+ * master pty). It then checks what reached that terminal:
+ *   - plain text and a 24-bit (true-colour) SGR sequence appear verbatim -
+ *     proving the terminal renders the child's real colours, not a 16-colour
+ *     reduction;
+ *   - a cursor-position-report query (CSI 6 n) does NOT appear - we answer it
+ *     ourselves, so it must not also reach the terminal;
+ *   - an OSC 52 clipboard write does NOT appear - we consume and publish it
+ *     (here, to the file override) instead of letting the terminal see it.
+ *
+ * Exits 77 ("skipped") when the environment can't support the setup.
+ */
+
+#include "prologue.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include "cmdline.h"
+#include "scr_terminal.h"
+
+#define SKIP_STATUS 77
+
+/* The child emits: a true-colour run "HELLO", a CPR query, and an OSC 52 write
+ * of "PASS" (base64 UEFTUw==). printf(1) interprets the backslash escapes. */
+#define TRUECOLOR_SGR "\033[38;2;10;200;30m"
+#define CHILD_COMMAND \
+  "printf '\\033[38;2;10;200;30mHELLO\\033[0m\\n\\033[6n'; " \
+  "printf '\\033]52;c;UEFTUw==\\007'; " \
+  "sleep 5"
+#define CLIPBOARD_EXPECTED "PASS"
+
+BEGIN_COMMAND_LINE_OPTIONS(programOptions)
+END_COMMAND_LINE_OPTIONS(programOptions)
+
+BEGIN_COMMAND_LINE_PARAMETERS(programParameters)
+END_COMMAND_LINE_PARAMETERS(programParameters)
+
+BEGIN_COMMAND_LINE_NOTES(programNotes)
+END_COMMAND_LINE_NOTES
+
+BEGIN_COMMAND_LINE_DESCRIPTOR(programDescriptor)
+  .name = "ptypass",
+  .purpose = strtext("Test brltty-pty's display passthrough end to end."),
+
+  .options = &programOptions,
+  .parameters = &programParameters,
+  .notes = COMMAND_LINE_NOTES(programNotes),
+END_COMMAND_LINE_DESCRIPTOR
+
+static long
+nowMilliseconds (void) {
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  return ((long)now.tv_sec * 1000) + (now.tv_usec / 1000);
+}
+
+/* Search a (possibly binary) buffer for a NUL-terminated needle. */
+static int
+bufferContains (const char *haystack, size_t length, const char *needle) {
+  size_t needleLength = strlen(needle);
+  if (needleLength == 0 || length < needleLength) return 0;
+
+  for (size_t i=0; i+needleLength<=length; i+=1) {
+    if (memcmp(haystack + i, needle, needleLength) == 0) return 1;
+  }
+
+  return 0;
+}
+
+static int
+fileContains (const char *path, const char *expected) {
+  FILE *file = fopen(path, "r");
+  if (!file) return 0;
+
+  char buffer[0X100] = {0};
+  size_t length = fread(buffer, 1, sizeof(buffer) - 1, file);
+  fclose(file);
+
+  return bufferContains(buffer, length, expected);
+}
+
+static int
+check (const char *label, int condition, int *failures) {
+  if (condition) {
+    fprintf(stderr, "  ok   %s\n", label);
+  } else {
+    fprintf(stderr, "  FAIL %s\n", label);
+    *failures += 1;
+  }
+
+  return condition;
+}
+
+int
+main (int argc, char *argv[]) {
+  PROCESS_COMMAND_LINE(programDescriptor, argc, argv);
+
+  int result = SKIP_STATUS;
+  int failures = 0;
+
+  char clipPath[0X100];
+  snprintf(clipPath, sizeof(clipPath), "/tmp/ptypass.clip.%d", (int)getpid());
+  unlink(clipPath);
+
+  int master = posix_openpt(O_RDWR | O_NOCTTY);
+  if (master == -1) return SKIP_STATUS;
+  if ((grantpt(master) == -1) || (unlockpt(master) == -1)) { close(master); return SKIP_STATUS; }
+
+  char slavePath[0X100];
+  {
+    const char *name = ptsname(master);
+    if (!name) { close(master); return SKIP_STATUS; }
+    snprintf(slavePath, sizeof(slavePath), "%s", name);
+  }
+
+  int sizedSlave = open(slavePath, O_RDWR);
+  {
+    struct winsize size = { .ws_row = 24, .ws_col = 80 };
+    ioctl((sizedSlave != -1)? sizedSlave: master, TIOCSWINSZ, &size);
+  }
+
+  int errorPipe[2];
+  if (pipe(errorPipe) == -1) { close(master); if (sizedSlave != -1) close(sizedSlave); return SKIP_STATUS; }
+
+  pid_t child = fork();
+  if (child == -1) {
+    close(master); if (sizedSlave != -1) close(sizedSlave);
+    close(errorPipe[0]); close(errorPipe[1]);
+    return SKIP_STATUS;
+  }
+
+  if (child == 0) {
+    setsid();
+    int slave = open(slavePath, O_RDWR);
+    if (slave == -1) _exit(SKIP_STATUS);
+#ifdef TIOCSCTTY
+    ioctl(slave, TIOCSCTTY, 0);
+#endif
+    dup2(slave, STDIN_FILENO);
+    dup2(slave, STDOUT_FILENO);
+    dup2(errorPipe[1], STDERR_FILENO);
+    close(master);
+    if (sizedSlave != -1) close(sizedSlave);
+    close(errorPipe[0]);
+    close(errorPipe[1]);
+    if (slave > STDERR_FILENO) close(slave);
+
+    setenv("TERM", "xterm-256color", 1);
+    /* Route any clipboard write to a file so OSC 52 isn't re-emitted to the
+     * outer pty by the clipboard layer (which would confuse the suppression
+     * check), and so we can confirm the OSC 52 was consumed. */
+    setenv("BRLTTY_PTY_CLIPBOARD_FILE", clipPath, 1);
+
+    execl("./brltty-pty", "brltty-pty", "--driver-directives",
+          "sh", "-c", CHILD_COMMAND, (char *)NULL);
+    _exit(SKIP_STATUS);
+  }
+
+  close(errorPipe[1]);
+  fcntl(master, F_SETFL, O_NONBLOCK);
+  fcntl(errorPipe[0], F_SETFL, O_NONBLOCK);
+
+  char outBuffer[0X4000];
+  size_t outLength = 0;
+
+  char ptyPath[0X100] = {0};
+  char errorText[0X1000];
+  size_t errorLength = 0;
+
+  /* Collect the outer-pty output and learn the inner pty path from stderr. We
+   * stop as soon as the POSITIVE markers have arrived - the passthrough text
+   * ("HELLO") and the consumed clipboard - so the negative assertions below
+   * ("CPR/OSC 52 not present") cannot pass spuriously just because output hadn't
+   * arrived yet. The deadline is only a backstop. */
+  const long deadline = nowMilliseconds() + 4000;
+  while (nowMilliseconds() < deadline) {
+    if (outLength < sizeof(outBuffer) - 1) {
+      ssize_t n = read(master, outBuffer + outLength, sizeof(outBuffer) - 1 - outLength);
+      if (n > 0) outLength += n;
+    }
+
+    if (!*ptyPath) {
+      struct pollfd pfd = { .fd = errorPipe[0], .events = POLLIN };
+      poll(&pfd, 1, 50);
+      ssize_t count = read(errorPipe[0], errorText + errorLength, sizeof(errorText) - errorLength - 1);
+      if (count > 0) {
+        errorLength += count;
+        errorText[errorLength] = 0;
+        char *line = errorText, *newline;
+        while ((newline = strchr(line, '\n'))) {
+          *newline = 0;
+          char *slash = strchr(line, '/');
+          if (slash) { snprintf(ptyPath, sizeof(ptyPath), "%s", slash); break; }
+          line = newline + 1;
+        }
+      }
+    } else {
+      /* Ready once both positive signals are in: text passed through and the
+       * clipboard was consumed (written to the file override). */
+      if (bufferContains(outBuffer, outLength, "HELLO") &&
+          fileContains(clipPath, CLIPBOARD_EXPECTED)) {
+        break;
+      }
+      usleep(50000);
+    }
+  }
+
+  if (!*ptyPath) {
+    fprintf(stderr, "  SKIP: brltty-pty did not start (likely sandboxed)\n");
+    goto cleanup;
+  }
+
+  result = PROG_EXIT_SUCCESS;
+
+  check("text passes through to the terminal",
+        bufferContains(outBuffer, outLength, "HELLO"), &failures);
+  check("true-colour SGR passes through verbatim",
+        bufferContains(outBuffer, outLength, TRUECOLOR_SGR), &failures);
+  check("CPR query is suppressed (we answer it)",
+        !bufferContains(outBuffer, outLength, "\033[6n"), &failures);
+  check("OSC 52 is suppressed (we publish it)",
+        !bufferContains(outBuffer, outLength, "\033]52;c;"), &failures);
+  check("OSC 52 was consumed by the clipboard layer",
+        fileContains(clipPath, CLIPBOARD_EXPECTED), &failures);
+
+  if (failures) result = PROG_EXIT_FATAL;
+
+cleanup:
+  if (child > 0) {
+    kill(child, SIGTERM);
+    int reaped = 0;
+    for (int i=0; i<20; i+=1) {
+      char scratch[0X400];
+      while (read(master, scratch, sizeof(scratch)) > 0);
+      if (waitpid(child, NULL, WNOHANG) == child) { reaped = 1; break; }
+      usleep(50000);
+    }
+    if (!reaped) { kill(child, SIGKILL); waitpid(child, NULL, 0); }
+  }
+
+  if (*ptyPath) {
+    key_t key = ftok(ptyPath, 't');
+    if (key != -1) {
+      int id = shmget(key, 0, 0);
+      if (id != -1) shmctl(id, IPC_RMID, NULL);
+    }
+  }
+
+  unlink(clipPath);
+  if (sizedSlave != -1) close(sizedSlave);
+  close(master);
+  close(errorPipe[0]);
+
+  fprintf(stderr, "\ndisplay passthrough: %s\n",
+          (result == PROG_EXIT_SUCCESS)? "all checks passed":
+          (result == SKIP_STATUS)? "skipped": "FAILED");
+  return result;
+}

--- a/Programs/ptyresize.c
+++ b/Programs/ptyresize.c
@@ -1,0 +1,295 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+/* End-to-end test for brltty-pty's dynamic screen resizing.
+ *
+ * It launches the real brltty-pty on its own pseudo-terminal, attaches to the
+ * published screen segment, then changes the controlling terminal's window size
+ * and raises SIGWINCH (exactly as a real terminal does when its window is
+ * resized). It verifies that brltty-pty republishes the segment at the new size
+ * - re-attaching by key, the way the brltty screen driver does - and that the
+ * existing content survives the resize.
+ *
+ * Exits with status 77 ("skipped") when the environment can't support it.
+ */
+
+#include "prologue.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include "cmdline.h"
+#include "scr_terminal.h"
+
+#define SKIP_STATUS 77
+
+BEGIN_COMMAND_LINE_OPTIONS(programOptions)
+END_COMMAND_LINE_OPTIONS(programOptions)
+
+BEGIN_COMMAND_LINE_PARAMETERS(programParameters)
+END_COMMAND_LINE_PARAMETERS(programParameters)
+
+BEGIN_COMMAND_LINE_NOTES(programNotes)
+END_COMMAND_LINE_NOTES
+
+BEGIN_COMMAND_LINE_DESCRIPTOR(programDescriptor)
+  .name = "ptyresize",
+  .purpose = strtext("Test brltty-pty dynamic screen resizing end to end."),
+
+  .options = &programOptions,
+  .parameters = &programParameters,
+  .notes = COMMAND_LINE_NOTES(programNotes),
+END_COMMAND_LINE_DESCRIPTOR
+
+static long
+nowMilliseconds (void) {
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  return ((long)now.tv_sec * 1000) + (now.tv_usec / 1000);
+}
+
+static void
+drain (int fd) {
+  char buffer[0X400];
+  while (read(fd, buffer, sizeof(buffer)) > 0);
+}
+
+/* Re-attach to the segment for a path (the emulator recreates it on resize, so
+ * the previous attachment becomes stale). Mirrors the screen driver's logic. */
+static ScreenSegmentHeader *
+reattach (ScreenSegmentHeader *old, const char *path) {
+  if (old) detachScreenSegment(old);
+  return getScreenSegmentForPath(path);
+}
+
+static int
+waitForSize (ScreenSegmentHeader **segment, const char *path, int master,
+             unsigned int wantWidth, unsigned int wantHeight) {
+  const long deadline = nowMilliseconds() + 4000;
+
+  while (nowMilliseconds() < deadline) {
+    drain(master);
+    *segment = reattach(*segment, path);
+
+    if (*segment &&
+        ((*segment)->screenWidth == wantWidth) &&
+        ((*segment)->screenHeight == wantHeight)) {
+      return 1;
+    }
+
+    usleep(50000);
+  }
+
+  return 0;
+}
+
+int
+main (int argc, char *argv[]) {
+  PROCESS_COMMAND_LINE(programDescriptor, argc, argv);
+
+  fprintf(stderr, "== resize scenario ==\n");
+
+  int master = posix_openpt(O_RDWR | O_NOCTTY);
+  if (master == -1) { fprintf(stderr, "  SKIP: no pty\n"); return SKIP_STATUS; }
+  if ((grantpt(master) == -1) || (unlockpt(master) == -1)) { close(master); return SKIP_STATUS; }
+
+  char slavePath[0X100];
+  {
+    const char *name = ptsname(master);
+    if (!name) { close(master); return SKIP_STATUS; }
+    snprintf(slavePath, sizeof(slavePath), "%s", name);
+  }
+
+  /* Keep a sized slave open (the macOS pty size only persists while one is). */
+  int sizedSlave = open(slavePath, O_RDWR);
+  {
+    struct winsize size = { .ws_row = 24, .ws_col = 80 };
+    ioctl((sizedSlave != -1)? sizedSlave: master, TIOCSWINSZ, &size);
+  }
+
+  int errorPipe[2];
+  if (pipe(errorPipe) == -1) { close(master); if (sizedSlave != -1) close(sizedSlave); return SKIP_STATUS; }
+
+  pid_t child = fork();
+  if (child == -1) { close(master); if (sizedSlave != -1) close(sizedSlave); return SKIP_STATUS; }
+
+  if (child == 0) {
+    setsid();
+    int slave = open(slavePath, O_RDWR);
+    if (slave == -1) _exit(SKIP_STATUS);
+#ifdef TIOCSCTTY
+    ioctl(slave, TIOCSCTTY, 0);
+#endif
+    dup2(slave, STDIN_FILENO);
+    dup2(slave, STDOUT_FILENO);
+    dup2(errorPipe[1], STDERR_FILENO);
+    close(master);
+    if (sizedSlave != -1) close(sizedSlave);
+    close(errorPipe[0]);
+    close(errorPipe[1]);
+    if (slave > STDERR_FILENO) close(slave);
+
+    setenv("TERM", "xterm-256color", 1);
+    /* Print a marker at the top-left, then idle so the screen stays put. */
+    execl("./brltty-pty", "brltty-pty", "--show-path",
+          "sh", "-c", "printf 'TOP'; sleep 30", (char *)NULL);
+    _exit(SKIP_STATUS);
+  }
+
+  close(errorPipe[1]);
+  fcntl(master, F_SETFL, O_NONBLOCK);
+  fcntl(errorPipe[0], F_SETFL, O_NONBLOCK);
+
+  int result = SKIP_STATUS;
+  ScreenSegmentHeader *segment = NULL;
+  char ptyPath[0X100] = {0};
+  char errorText[0X1000];
+  size_t errorLength = 0;
+  const long deadline = nowMilliseconds() + 8000;
+
+  /* Learn the inner pty path from --show-path output. */
+  while (!*ptyPath && (nowMilliseconds() < deadline)) {
+    drain(master);
+    struct pollfd pfd = { .fd = errorPipe[0], .events = POLLIN };
+    poll(&pfd, 1, 50);
+    ssize_t count = read(errorPipe[0], errorText + errorLength, sizeof(errorText) - errorLength - 1);
+    if (count > 0) {
+      errorLength += count;
+      errorText[errorLength] = 0;
+      char *line = errorText, *newline;
+      while ((newline = strchr(line, '\n'))) {
+        *newline = 0;
+        if (line[0] == '/') { snprintf(ptyPath, sizeof(ptyPath), "%s", line); break; }
+        line = newline + 1;
+      }
+    }
+  }
+
+  if (!*ptyPath) {
+    fprintf(stderr, "  SKIP: brltty-pty did not start (likely sandboxed)\n");
+    goto cleanup;
+  }
+
+  /* Wait for the initial 80x24 segment with the marker rendered. */
+  if (!waitForSize(&segment, ptyPath, master, 80, 24)) {
+    fprintf(stderr, "  SKIP: initial segment unavailable (likely sandboxed)\n");
+    goto cleanup;
+  }
+  fprintf(stderr, "  ok   initial size 80x24\n");
+
+  {
+    const ScreenSegmentCharacter *cell = getScreenCharacter(segment, 0, 0, NULL);
+    if (!cell || (cell->text != 'T')) {
+      fprintf(stderr, "  FAIL: marker not rendered before resize\n");
+      result = PROG_EXIT_FATAL;
+      goto cleanup;
+    }
+  }
+
+  /* --- Grow to 100x30 --- */
+  {
+    struct winsize size = { .ws_row = 30, .ws_col = 100 };
+    ioctl((sizedSlave != -1)? sizedSlave: master, TIOCSWINSZ, &size);
+    kill(child, SIGWINCH);
+  }
+
+  if (!waitForSize(&segment, ptyPath, master, 100, 30)) {
+    fprintf(stderr, "  FAIL: segment did not grow to 100x30 (got %ux%u)\n",
+            segment? segment->screenWidth: 0, segment? segment->screenHeight: 0);
+    result = PROG_EXIT_FATAL;
+    goto cleanup;
+  }
+  fprintf(stderr, "  ok   grew to 100x30\n");
+
+  {
+    /* Content preserved, and the new bottom-right cell is addressable. */
+    const ScreenSegmentCharacter *top = getScreenCharacter(segment, 0, 0, NULL);
+    const ScreenSegmentCharacter *corner = getScreenCharacter(segment, 29, 99, NULL);
+    if (!top || (top->text != 'T')) {
+      fprintf(stderr, "  FAIL: content lost after growing\n");
+      result = PROG_EXIT_FATAL;
+      goto cleanup;
+    }
+    if (!corner) {
+      fprintf(stderr, "  FAIL: new corner cell not addressable\n");
+      result = PROG_EXIT_FATAL;
+      goto cleanup;
+    }
+    fprintf(stderr, "  ok   content preserved and new area addressable\n");
+  }
+
+  /* --- Shrink to 60x20 --- */
+  {
+    struct winsize size = { .ws_row = 20, .ws_col = 60 };
+    ioctl((sizedSlave != -1)? sizedSlave: master, TIOCSWINSZ, &size);
+    kill(child, SIGWINCH);
+  }
+
+  if (!waitForSize(&segment, ptyPath, master, 60, 20)) {
+    fprintf(stderr, "  FAIL: segment did not shrink to 60x20 (got %ux%u)\n",
+            segment? segment->screenWidth: 0, segment? segment->screenHeight: 0);
+    result = PROG_EXIT_FATAL;
+    goto cleanup;
+  }
+  fprintf(stderr, "  ok   shrank to 60x20\n");
+
+  result = PROG_EXIT_SUCCESS;
+
+cleanup:
+  if (segment) detachScreenSegment(segment);
+
+  if (child > 0) {
+    kill(child, SIGTERM);
+    int reaped = 0;
+    for (int i=0; i<20; i+=1) {
+      drain(master);
+      if (waitpid(child, NULL, WNOHANG) == child) { reaped = 1; break; }
+      usleep(50000);
+    }
+    if (!reaped) { kill(child, SIGKILL); waitpid(child, NULL, 0); }
+  }
+
+  if (*ptyPath) {
+    key_t key = ftok(ptyPath, 't');
+    if (key != -1) {
+      int identifier = shmget(key, 0, 0);
+      if (identifier != -1) shmctl(identifier, IPC_RMID, NULL);
+    }
+  }
+
+  if (sizedSlave != -1) close(sizedSlave);
+  close(master);
+  close(errorPipe[0]);
+
+  if (result == PROG_EXIT_SUCCESS) fprintf(stderr, "\nresize: all checks passed\n");
+  else if (result == SKIP_STATUS) fprintf(stderr, "\nresize: skipped\n");
+  else fprintf(stderr, "\nresize: FAILED\n");
+
+  return result;
+}

--- a/Programs/ptytest.c
+++ b/Programs/ptytest.c
@@ -1,0 +1,519 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+/* End-to-end test for brltty-pty's UTF-8 / wide-character rendering.
+ *
+ * It launches the real brltty-pty binary on its own pseudo-terminal, has it
+ * run a child that prints a known UTF-8 string (box-drawing, accented and
+ * 4-byte characters), then attaches to the shared-memory screen segment that
+ * brltty-pty publishes and checks that each cell holds the expected Unicode
+ * code point.
+ *
+ * Because it depends on pseudo-terminal allocation and System V shared memory,
+ * it exits with status 77 (the conventional "skipped" code) when the
+ * environment cannot support the setup, rather than reporting a false failure.
+ */
+
+#include "prologue.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include "cmdline.h"
+#include "scr_terminal.h"
+
+#define SKIP_STATUS 77
+
+BEGIN_COMMAND_LINE_OPTIONS(programOptions)
+END_COMMAND_LINE_OPTIONS(programOptions)
+
+BEGIN_COMMAND_LINE_PARAMETERS(programParameters)
+END_COMMAND_LINE_PARAMETERS(programParameters)
+
+BEGIN_COMMAND_LINE_NOTES(programNotes)
+END_COMMAND_LINE_NOTES
+
+BEGIN_COMMAND_LINE_DESCRIPTOR(programDescriptor)
+  .name = "ptytest",
+  .purpose = strtext("Test brltty-pty UTF-8/wide-character screen rendering end to end."),
+
+  .options = &programOptions,
+  .parameters = &programParameters,
+  .notes = COMMAND_LINE_NOTES(programNotes),
+END_COMMAND_LINE_DESCRIPTOR
+
+typedef struct {
+  unsigned int row;
+  unsigned int column;
+  uint32_t expected;
+} ExpectedCell;
+
+typedef struct {
+  const char *name;
+  unsigned short rows; /* terminal size to run at (0 => default 24x80) */
+  unsigned short cols;
+  const char *emit; /* sh command that prints the test bytes (no trailing sleep) */
+  const ExpectedCell *cells;
+  unsigned int cellCount;
+  unsigned int readyRow; /* cell whose appearance means rendering is complete */
+  unsigned int readyColumn;
+  uint32_t readyValue;
+  const char *clipboardExpected; /* if set, OSC 52 must deliver this text */
+} Scenario;
+
+/* Scenario 1 - UTF-8 / wide rendering. Raw UTF-8 bytes printed:
+ *   U+256D U+2500 U+256E  (rounded box: top-left, horizontal, top-right)
+ *   ' '  'h'  'i'  ' '
+ *   U+00E9 (e-acute)
+ *   U+1F600 (grinning face - a 4-byte, double-width emoji)
+ */
+static const ExpectedCell utf8Cells[] = {
+  { 0, 0, 0X256D }, { 0, 1, 0X2500 }, { 0, 2, 0X256E },
+  { 0, 3, ' '    }, { 0, 4, 'h'    }, { 0, 5, 'i'    }, { 0, 6, ' ' },
+  { 0, 7, 0X00E9 }, { 0, 8, 0X1F600 },
+};
+
+/* Scenario 2 - deferred wrap (xenl / magic margin). Print exactly one screen
+ * width of 'A', then CR-LF, then 'X'. A terminal with correct deferred wrap
+ * leaves 'X' at the start of the very next row; one that wraps immediately
+ * inserts a spurious blank line, pushing 'X' down a row (the bug that garbled
+ * Claude Code's input box). We assert 'X' is on row 1, not row 2.
+ */
+static const ExpectedCell wrapCells[] = {
+  { 0,  0, 'A' },
+  { 0, 79, 'A' },
+  { 1,  0, 'X' },
+};
+
+/* Scenario 3 - the alternate screen (smcup, "\E[?1049h") must present a
+ * cleared buffer. Print old content, switch to the alternate screen, home the
+ * cursor and write new text. A correct emulator shows only the new text; the
+ * bug this guards against left the old content behind, so full-screen programs
+ * (Claude Code, editors) drew on top of stale text. We assert the new text is
+ * present and that a cell that held old content is now blank.
+ */
+static const ExpectedCell altScreenCells[] = {
+  { 0, 0, 'X' }, { 0, 1, 'Y' },
+  { 0, 2, ' ' }, /* was 'C' before smcup */
+  { 0, 4, ' ' }, /* was 'E' before smcup */
+};
+
+/* Scenario 4 - arbitrary (non 80x24) screen size. The emulated screen must
+ * match the real terminal, not a hardcoded 80x24. Printed at the bottom-right
+ * region so the assertions only pass if the screen really is that large.
+ */
+static const ExpectedCell bigSizeCells[] = {
+  { 0, 0, 'T' }, { 0, 1, 'L' },
+  { 39, 0, 'B' }, { 39, 1, 'L' },
+};
+
+/* Scenario 5 - clear whole display (CSI 2J). Old content must be gone. */
+static const ExpectedCell clearDisplayCells[] = {
+  { 0, 0, 'Z' }, { 0, 1, ' ' }, { 0, 2, ' ' }, { 1, 0, ' ' },
+};
+
+/* Scenario 6 - repeat character (CSI b / REP), used by ncurses' rep. */
+static const ExpectedCell repeatCells[] = {
+  { 0, 0, 'A' }, { 0, 4, 'A' }, { 0, 5, ' ' },
+};
+
+/* Scenario 7 - erase characters in place (CSI X / ECH). */
+static const ExpectedCell eraseCells[] = {
+  { 0, 0, 'Z' }, { 0, 1, ' ' }, { 0, 2, 'C' },
+};
+
+/* Scenario 8 - VT100 line drawing (ESC ( 0). "lqk" must render as the box
+ * glyphs U+250C U+2500 U+2510, not as the letters l, q, k. */
+static const ExpectedCell lineDrawingCells[] = {
+  { 0, 0, 0X250C }, { 0, 1, 0X2500 }, { 0, 2, 0X2510 },
+};
+
+/* Scenario 9 - keyboard-protocol negotiation (modifyOtherKeys "CSI > 4 ; 2 m"
+ * and kitty "CSI > 1 u") must be swallowed, not misread as SGR or leaked as
+ * text. The surrounding A/B/C must land in consecutive cells. */
+static const ExpectedCell keyboardModeCells[] = {
+  { 0, 0, 'A' }, { 0, 1, 'B' }, { 0, 2, 'C' },
+};
+
+/* Scenario 10 - OSC 52 sets the clipboard ("OSC52!" = base64 T1NDNTIh) and is
+ * consumed without leaking; the surrounding X/Y must be in consecutive cells. */
+static const ExpectedCell clipboardCells[] = {
+  { 0, 0, 'X' }, { 0, 1, 'Y' },
+};
+
+static const Scenario scenarios[] = {
+  {
+    .name = "utf8/wide rendering",
+    .emit = "printf '\\342\\225\\255\\342\\224\\200\\342\\225\\256 hi \\303\\251\\360\\237\\230\\200'",
+    .cells = utf8Cells, .cellCount = ARRAY_COUNT(utf8Cells),
+    .readyRow = 0, .readyColumn = 8, .readyValue = 0X1F600,
+  },
+  {
+    .name = "deferred wrap (xenl)",
+    .emit = "printf '%080d' 0 | tr 0 A; printf '\\r\\nX'",
+    .cells = wrapCells, .cellCount = ARRAY_COUNT(wrapCells),
+    .readyRow = 1, .readyColumn = 0, .readyValue = 'X',
+  },
+  {
+    .name = "alternate screen clears (smcup)",
+    .emit = "printf 'ABCDE\\033[?1049h\\033[HXY'",
+    .cells = altScreenCells, .cellCount = ARRAY_COUNT(altScreenCells),
+    .readyRow = 0, .readyColumn = 1, .readyValue = 'Y',
+  },
+  {
+    .name = "arbitrary screen size (40x120)",
+    .rows = 40, .cols = 120,
+    .emit = "printf 'TL\\033[40;1HBL'",
+    .cells = bigSizeCells, .cellCount = ARRAY_COUNT(bigSizeCells),
+    .readyRow = 39, .readyColumn = 1, .readyValue = 'L',
+  },
+  {
+    .name = "clear display (CSI 2J)",
+    .emit = "printf 'AAAA\\r\\nBBBB\\033[2J\\033[HZ'",
+    .cells = clearDisplayCells, .cellCount = ARRAY_COUNT(clearDisplayCells),
+    .readyRow = 0, .readyColumn = 0, .readyValue = 'Z',
+  },
+  {
+    .name = "repeat character (CSI b)",
+    .emit = "printf 'A\\033[4b'",
+    .cells = repeatCells, .cellCount = ARRAY_COUNT(repeatCells),
+    .readyRow = 0, .readyColumn = 4, .readyValue = 'A',
+  },
+  {
+    .name = "erase characters (CSI X)",
+    .emit = "printf 'ABCDE\\033[1;1H\\033[2XZ'",
+    .cells = eraseCells, .cellCount = ARRAY_COUNT(eraseCells),
+    .readyRow = 0, .readyColumn = 0, .readyValue = 'Z',
+  },
+  {
+    .name = "VT100 line drawing (ESC ( 0)",
+    .emit = "printf '\\033(0lqk\\033(B'",
+    .cells = lineDrawingCells, .cellCount = ARRAY_COUNT(lineDrawingCells),
+    .readyRow = 0, .readyColumn = 2, .readyValue = 0X2510,
+  },
+  {
+    .name = "keyboard-protocol negotiation swallowed",
+    .emit = "printf 'A\\033[>4;2mB\\033[>1uC'",
+    .cells = keyboardModeCells, .cellCount = ARRAY_COUNT(keyboardModeCells),
+    .readyRow = 0, .readyColumn = 2, .readyValue = 'C',
+  },
+  {
+    .name = "OSC 52 sets clipboard",
+    .emit = "printf 'X\\033]52;c;T1NDNTIh\\007Y'",
+    .cells = clipboardCells, .cellCount = ARRAY_COUNT(clipboardCells),
+    .readyRow = 0, .readyColumn = 1, .readyValue = 'Y',
+    .clipboardExpected = "OSC52!",
+  },
+};
+
+static long
+nowMilliseconds (void) {
+  struct timeval now;
+  gettimeofday(&now, NULL);
+  return ((long)now.tv_sec * 1000) + (now.tv_usec / 1000);
+}
+
+/* Read and discard whatever brltty-pty writes to its controlling terminal so
+ * its rendering never blocks on a full pty buffer. */
+static void
+drain (int fd) {
+  char buffer[0X400];
+  while (read(fd, buffer, sizeof(buffer)) > 0);
+}
+
+/* Run one scenario through a freshly spawned brltty-pty.
+ * Returns PROG_EXIT_SUCCESS, PROG_EXIT_FATAL (assertion failed), or
+ * SKIP_STATUS (the environment could not support the test). */
+static int
+runScenario (const Scenario *scenario) {
+  fprintf(stderr, "\n== scenario: %s ==\n", scenario->name);
+
+  int master = posix_openpt(O_RDWR | O_NOCTTY);
+  if (master == -1) {
+    fprintf(stderr, "  posix_openpt: %s\n", strerror(errno));
+    fprintf(stderr, "  SKIP: cannot allocate a pseudo-terminal\n");
+    return SKIP_STATUS;
+  }
+
+  if ((grantpt(master) == -1) || (unlockpt(master) == -1)) {
+    close(master);
+    return SKIP_STATUS;
+  }
+
+  char slavePath[0X100];
+  {
+    const char *name = ptsname(master);
+    if (!name) { close(master); return SKIP_STATUS; }
+    snprintf(slavePath, sizeof(slavePath), "%s", name);
+  }
+
+  /* A freshly allocated pty reports a 0x0 window, which would make curses
+   * build a zero-size screen. Give it a normal size.
+   *
+   * On macOS a pty's window size is only retained while a slave fd is open,
+   * and setting it on the master before any slave exists is silently ignored.
+   * Open a slave here, set the size on it, and keep it open for the lifetime
+   * of the test so brltty-pty sees a properly sized controlling terminal. */
+  unsigned short rows = scenario->rows? scenario->rows: 24;
+  unsigned short cols = scenario->cols? scenario->cols: 80;
+  int sizedSlave = open(slavePath, O_RDWR);
+  {
+    struct winsize size = { .ws_row = rows, .ws_col = cols };
+    ioctl((sizedSlave != -1)? sizedSlave: master, TIOCSWINSZ, &size);
+  }
+
+  int errorPipe[2];
+  if (pipe(errorPipe) == -1) { close(master); return SKIP_STATUS; }
+
+  char clipPath[0X100];
+  snprintf(clipPath, sizeof(clipPath), "/tmp/ptytest.clip.%d", (int)getpid());
+  if (scenario->clipboardExpected) unlink(clipPath);
+
+  char command[0X400];
+  snprintf(command, sizeof(command), "%s; sleep 30", scenario->emit);
+
+  pid_t child = fork();
+  if (child == -1) { close(master); close(errorPipe[0]); close(errorPipe[1]); return SKIP_STATUS; }
+
+  if (child == 0) {
+    /* Child: become a session leader, adopt the outer pty as its controlling
+     * terminal, then exec the real brltty-pty. */
+    setsid();
+
+    int slave = open(slavePath, O_RDWR);
+    if (slave == -1) _exit(SKIP_STATUS);
+
+#ifdef TIOCSCTTY
+    ioctl(slave, TIOCSCTTY, 0);
+#endif
+
+    dup2(slave, STDIN_FILENO);
+    dup2(slave, STDOUT_FILENO);
+    dup2(errorPipe[1], STDERR_FILENO);
+
+    close(master);
+    close(errorPipe[0]);
+    close(errorPipe[1]);
+    if (slave > STDERR_FILENO) close(slave);
+
+    setenv("TERM", "xterm-256color", 1);
+    if (scenario->clipboardExpected) setenv("BRLTTY_PTY_CLIPBOARD_FILE", clipPath, 1);
+
+    execl("./brltty-pty", "brltty-pty", "--show-path",
+          "sh", "-c", command, (char *)NULL);
+    _exit(SKIP_STATUS); /* exec failed */
+  }
+
+  close(errorPipe[1]);
+  fcntl(master, F_SETFL, O_NONBLOCK);
+  fcntl(errorPipe[0], F_SETFL, O_NONBLOCK);
+
+  int result = SKIP_STATUS;
+  ScreenSegmentHeader *segment = NULL;
+  char ptyPath[0X100] = {0};
+  char errorText[0X1000];
+  size_t errorLength = 0;
+  const long deadline = nowMilliseconds() + 12000;
+
+  /* Phase 1: learn the inner pty path from brltty-pty's --show-path output. */
+  while (!*ptyPath && (nowMilliseconds() < deadline)) {
+    drain(master);
+
+    struct pollfd pfd = { .fd = errorPipe[0], .events = POLLIN };
+    poll(&pfd, 1, 50);
+
+    ssize_t count = read(errorPipe[0], errorText + errorLength,
+                         sizeof(errorText) - errorLength - 1);
+    if (count > 0) {
+      errorLength += count;
+      errorText[errorLength] = 0;
+
+      char *line = errorText;
+      char *newline;
+      while ((newline = strchr(line, '\n'))) {
+        *newline = 0;
+        if (line[0] == '/') {
+          snprintf(ptyPath, sizeof(ptyPath), "%s", line);
+          break;
+        }
+        line = newline + 1;
+      }
+    }
+  }
+
+  if (!*ptyPath) {
+    fprintf(stderr, "  SKIP: brltty-pty did not start (likely a sandboxed environment)\n");
+    if (errorLength) fprintf(stderr, "  brltty-pty stderr: %s\n", errorText);
+    goto cleanup;
+  }
+
+  /* Phase 2: attach to the published screen segment. */
+  while (!segment && (nowMilliseconds() < deadline)) {
+    drain(master);
+    segment = getScreenSegmentForPath(ptyPath);
+    if (!segment) usleep(50000);
+  }
+
+  if (!segment) {
+    fprintf(stderr, "  SKIP: shared-memory segment unavailable (likely sandboxed)\n");
+    goto cleanup;
+  }
+
+  /* Phase 3: wait until the readiness cell has been rendered. */
+  int rendered = 0;
+  while (!rendered && (nowMilliseconds() < deadline)) {
+    drain(master);
+    const ScreenSegmentCharacter *cell =
+      getScreenCharacter(segment, scenario->readyRow, scenario->readyColumn, NULL);
+    if (cell && (cell->text == scenario->readyValue)) rendered = 1;
+    if (!rendered) usleep(20000);
+  }
+
+  if (!rendered) {
+    fprintf(stderr, "  FAIL: expected text was never rendered\n");
+    fprintf(stderr, "    segment %ux%u cursor=(%u,%u)\n",
+            segment->screenWidth, segment->screenHeight,
+            segment->cursorRow, segment->cursorColumn);
+    result = PROG_EXIT_FATAL;
+    goto cleanup;
+  }
+
+  {
+    unsigned int failures = 0;
+
+    if ((segment->screenHeight != rows) || (segment->screenWidth != cols)) {
+      failures += 1;
+      fprintf(stderr, "  FAIL size: got %ux%u, expected %ux%u\n",
+              segment->screenWidth, segment->screenHeight, cols, rows);
+    } else {
+      fprintf(stderr, "  ok   size: %ux%u\n", cols, rows);
+    }
+
+    for (unsigned int i=0; i<scenario->cellCount; i+=1) {
+      const ExpectedCell *e = &scenario->cells[i];
+      const ScreenSegmentCharacter *cell = getScreenCharacter(segment, e->row, e->column, NULL);
+      uint32_t got = cell? cell->text: 0;
+
+      if (got == e->expected) {
+        fprintf(stderr, "  ok   (%u,%u): U+%04X\n", e->row, e->column, (unsigned int)e->expected);
+      } else {
+        failures += 1;
+        fprintf(stderr, "  FAIL (%u,%u): got U+%04X, expected U+%04X\n",
+                e->row, e->column, (unsigned int)got, (unsigned int)e->expected);
+      }
+    }
+
+    if (scenario->clipboardExpected) {
+      char got[0X100] = {0};
+      size_t expectedLength = strlen(scenario->clipboardExpected);
+
+      /* The clipboard is written when OSC 52 is processed; give it a moment. */
+      for (int i=0; i<20; i+=1) {
+        drain(master);
+        int fd = open(clipPath, O_RDONLY);
+        if (fd != -1) {
+          ssize_t n = read(fd, got, sizeof(got) - 1);
+          close(fd);
+          if (n >= 0) got[n] = 0;
+          if (strlen(got) >= expectedLength) break;
+        }
+        usleep(50000);
+      }
+
+      if (strcmp(got, scenario->clipboardExpected) == 0) {
+        fprintf(stderr, "  ok   clipboard: \"%s\"\n", got);
+      } else {
+        failures += 1;
+        fprintf(stderr, "  FAIL clipboard: got \"%s\", expected \"%s\"\n",
+                got, scenario->clipboardExpected);
+      }
+    }
+
+    result = failures? PROG_EXIT_FATAL: PROG_EXIT_SUCCESS;
+    fprintf(stderr, "  %u cell(s) checked, %u failed\n", scenario->cellCount, failures);
+  }
+
+cleanup:
+  if (scenario->clipboardExpected) unlink(clipPath);
+  if (sizedSlave != -1) close(sizedSlave);
+  if (segment) detachScreenSegment(segment);
+
+  /* Tear down brltty-pty without ever blocking: ask politely, then escalate. */
+  if (child > 0) {
+    kill(child, SIGTERM);
+
+    int reaped = 0;
+    for (int i=0; i<20; i+=1) { /* up to ~1 second */
+      drain(master);
+      if (waitpid(child, NULL, WNOHANG) == child) { reaped = 1; break; }
+      usleep(50000);
+    }
+
+    if (!reaped) {
+      kill(child, SIGKILL);
+      waitpid(child, NULL, 0);
+    }
+  }
+
+  /* Remove the shared-memory segment even if brltty-pty was killed before it
+   * could clean up itself, so repeated runs never attach to a stale segment. */
+  if (*ptyPath) {
+    key_t key = ftok(ptyPath, 't');
+
+    if (key != -1) {
+      int identifier = shmget(key, 0, 0);
+      if (identifier != -1) shmctl(identifier, IPC_RMID, NULL);
+    }
+  }
+
+  close(master);
+  close(errorPipe[0]);
+  return result;
+}
+
+int
+main (int argc, char *argv[]) {
+  PROCESS_COMMAND_LINE(programDescriptor, argc, argv);
+
+  unsigned int failed = 0;
+  unsigned int skipped = 0;
+
+  for (unsigned int i=0; i<ARRAY_COUNT(scenarios); i+=1) {
+    int result = runScenario(&scenarios[i]);
+    if (result == PROG_EXIT_FATAL) failed += 1;
+    else if (result == SKIP_STATUS) skipped += 1;
+  }
+
+  fprintf(stderr, "\n%u scenario(s): %u failed, %u skipped\n",
+          (unsigned int)ARRAY_COUNT(scenarios), failed, skipped);
+
+  if (failed) return PROG_EXIT_FATAL;
+  if (skipped == ARRAY_COUNT(scenarios)) return SKIP_STATUS;
+  return PROG_EXIT_SUCCESS;
+}

--- a/Programs/scr_emulator.c
+++ b/Programs/scr_emulator.c
@@ -19,6 +19,13 @@
 #include "prologue.h"
 
 #include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <signal.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <limits.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/msg.h>
 #include <sys/shm.h>
@@ -283,4 +290,76 @@ createMessageQueue (int *queue, key_t key) {
   }
 
   return 0;
+}
+
+/* Registry of SysV IPC objects created by terminal emulator instances, so a
+ * new instance can reap what a predecessor leaked by dying uncleanly. Entries
+ * live directly in /tmp (which every emulator, whatever user it runs as, can
+ * write to) as empty files named to carry their own payload, so reaping never
+ * has to open/parse a file - just list the directory and stat a pid. */
+#define TERMINAL_RESOURCES_DIRECTORY "/tmp"
+#define TERMINAL_RESOURCES_PREFIX ".brltty-pty-ipc."
+
+static char registeredResourcesPath[PATH_MAX] = "";
+
+static int
+terminalResourceOwnerIsAlive (pid_t pid) {
+  if (kill(pid, 0) != -1) return 1;
+  return errno != ESRCH;
+}
+
+void
+reapStaleTerminalResources (void) {
+  DIR *directory = opendir(TERMINAL_RESOURCES_DIRECTORY);
+  if (!directory) return;
+
+  const size_t prefixLength = strlen(TERMINAL_RESOURCES_PREFIX);
+  struct dirent *entry;
+
+  while ((entry = readdir(directory))) {
+    if (strncmp(entry->d_name, TERMINAL_RESOURCES_PREFIX, prefixLength) != 0) continue;
+
+    long pid, shmId, msgId;
+    if (sscanf(entry->d_name + prefixLength, "%ld.%ld.%ld", &pid, &shmId, &msgId) != 3) continue;
+    if (terminalResourceOwnerIsAlive((pid_t)pid)) continue;
+
+    logMessage(LOG_WARNING,
+      "reaping terminal emulator resources leaked by dead process %ld: shm=%ld msg=%ld",
+      pid, shmId, msgId
+    );
+
+    if (shmId >= 0) shmctl((int)shmId, IPC_RMID, NULL);
+    if (msgId >= 0) msgctl((int)msgId, IPC_RMID, NULL);
+
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "%s/%s", TERMINAL_RESOURCES_DIRECTORY, entry->d_name);
+    unlink(path);
+  }
+
+  closedir(directory);
+}
+
+void
+registerTerminalResources (int screenSegmentIdentifier, int messageQueueIdentifier) {
+  snprintf(
+    registeredResourcesPath, sizeof(registeredResourcesPath),
+    "%s/%s%ld.%d.%d", TERMINAL_RESOURCES_DIRECTORY, TERMINAL_RESOURCES_PREFIX,
+    (long)getpid(), screenSegmentIdentifier, messageQueueIdentifier
+  );
+
+  int descriptor = open(registeredResourcesPath, O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
+  if (descriptor != -1) {
+    close(descriptor);
+  } else {
+    logSystemError("open[terminal resources registry entry]");
+    registeredResourcesPath[0] = 0;
+  }
+}
+
+void
+unregisterTerminalResources (void) {
+  if (registeredResourcesPath[0]) {
+    unlink(registeredResourcesPath);
+    registeredResourcesPath[0] = 0;
+  }
 }

--- a/Programs/scr_emulator.c
+++ b/Programs/scr_emulator.c
@@ -308,6 +308,22 @@ terminalResourceOwnerIsAlive (pid_t pid) {
   return errno != ESRCH;
 }
 
+/* /tmp is world-writable, and this directory is scanned for a dead pid rather
+ * than authenticated some other way, so a local user could plant a marker
+ * naming a live pid=irrelevant, dead-pid=fabricated, {shm,msg} id belonging to
+ * an unrelated process (ids are small, kernel-recycled integers, and readable
+ * system-wide via ipcs). Since a reaping instance can run as root (BRLTTY is
+ * commonly started via sudo), skipping this check would let an unprivileged
+ * local user trick root into destroying an arbitrary SysV object on the
+ * machine. Requiring the object's creator uid to match the marker file's own
+ * owner ties "who could plausibly have registered this marker" to "who
+ * actually owns the object" - an attacker can only plant markers owned by
+ * themselves, so this fails closed for anything they don't already own. */
+static int
+terminalResourceOwnedBy (uid_t owner, uid_t creatorUid) {
+  return creatorUid == owner;
+}
+
 void
 reapStaleTerminalResources (void) {
   DIR *directory = opendir(TERMINAL_RESOURCES_DIRECTORY);
@@ -323,16 +339,44 @@ reapStaleTerminalResources (void) {
     if (sscanf(entry->d_name + prefixLength, "%ld.%ld.%ld", &pid, &shmId, &msgId) != 3) continue;
     if (terminalResourceOwnerIsAlive((pid_t)pid)) continue;
 
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "%s/%s", TERMINAL_RESOURCES_DIRECTORY, entry->d_name);
+
+    struct stat markerStatus;
+    if (stat(path, &markerStatus) == -1) continue;
+    uid_t owner = markerStatus.st_uid;
+
     logMessage(LOG_WARNING,
       "reaping terminal emulator resources leaked by dead process %ld: shm=%ld msg=%ld",
       pid, shmId, msgId
     );
 
-    if (shmId >= 0) shmctl((int)shmId, IPC_RMID, NULL);
-    if (msgId >= 0) msgctl((int)msgId, IPC_RMID, NULL);
+    if (shmId >= 0) {
+      struct shmid_ds shmStatus;
 
-    char path[PATH_MAX];
-    snprintf(path, sizeof(path), "%s/%s", TERMINAL_RESOURCES_DIRECTORY, entry->d_name);
+      if (shmctl((int)shmId, IPC_STAT, &shmStatus) == -1) {
+        /* Already gone - nothing to remove. */
+      } else if (terminalResourceOwnedBy(owner, shmStatus.shm_perm.cuid)) {
+        shmctl((int)shmId, IPC_RMID, NULL);
+      } else {
+        logMessage(LOG_WARNING,
+          "refusing to reap shm %ld: owned by a different user than its registry marker", shmId);
+      }
+    }
+
+    if (msgId >= 0) {
+      struct msqid_ds msgStatus;
+
+      if (msgctl((int)msgId, IPC_STAT, &msgStatus) == -1) {
+        /* Already gone - nothing to remove. */
+      } else if (terminalResourceOwnedBy(owner, msgStatus.msg_perm.cuid)) {
+        msgctl((int)msgId, IPC_RMID, NULL);
+      } else {
+        logMessage(LOG_WARNING,
+          "refusing to reap message queue %ld: owned by a different user than its registry marker", msgId);
+      }
+    }
+
     unlink(path);
   }
 

--- a/Programs/utf8.c
+++ b/Programs/utf8.c
@@ -151,6 +151,74 @@ convertUtf8ToWchar (const char **utf8, size_t *utfs) {
   return codepoint;
 }
 
+Utf8DecodeResult
+putUtf8StreamByte (
+  Utf8StreamDecoder *decoder, unsigned char byte,
+  wchar_t *character, int *reprocess
+) {
+  *reprocess = 0;
+
+  if (decoder->pending > 0) {
+    if ((byte & 0XC0) == 0X80) {
+      decoder->codepoint = (decoder->codepoint << 6) | (byte & 0X3F);
+
+      if (--decoder->pending > 0) return UTF8_DECODE_PENDING;
+
+      uint32_t codepoint = decoder->codepoint;
+      uint32_t minimum = decoder->minimum;
+      decoder->codepoint = 0;
+      decoder->minimum = 0;
+
+      if (codepoint < minimum) goto invalid; /* overlong encoding */
+      if (codepoint > 0X10FFFF) goto invalid; /* beyond Unicode */
+      if ((codepoint >= 0XD800) && (codepoint <= 0XDFFF)) goto invalid; /* surrogate */
+      if (codepoint > WCHAR_MAX) codepoint = UNICODE_REPLACEMENT_CHARACTER;
+
+      *character = codepoint;
+      return UTF8_DECODE_DONE;
+    }
+
+    /* A non-continuation byte arrived mid-sequence: the partial character is
+     * truncated. Report it as invalid and let the caller reprocess this byte
+     * as the potential start of a new character.
+     */
+    decoder->codepoint = 0;
+    decoder->minimum = 0;
+    decoder->pending = 0;
+    *reprocess = 1;
+    goto invalid;
+  }
+
+  if (byte < 0X80) { /* 0xxxxxxx - ASCII */
+    *character = byte;
+    return UTF8_DECODE_DONE;
+  }
+
+  if (byte < 0XC0) goto invalid; /* 10xxxxxx - stray continuation byte */
+
+  if (byte < 0XE0) { /* 110xxxxx - 2 bytes */
+    decoder->codepoint = byte & 0X1F;
+    decoder->pending = 1;
+    decoder->minimum = 0X80;
+  } else if (byte < 0XF0) { /* 1110xxxx - 3 bytes */
+    decoder->codepoint = byte & 0X0F;
+    decoder->pending = 2;
+    decoder->minimum = 0X800;
+  } else if (byte < 0XF8) { /* 11110xxx - 4 bytes */
+    decoder->codepoint = byte & 0X07;
+    decoder->pending = 3;
+    decoder->minimum = 0X10000;
+  } else { /* 11111xxx - invalid lead byte */
+    goto invalid;
+  }
+
+  return UTF8_DECODE_PENDING;
+
+invalid:
+  *character = UNICODE_REPLACEMENT_CHARACTER;
+  return UTF8_DECODE_INVALID;
+}
+
 void
 convertUtf8ToWchars (const char **utf8, wchar_t **characters, size_t count) {
   while (**utf8 && (count > 1)) {

--- a/Programs/utf8test.c
+++ b/Programs/utf8test.c
@@ -1,0 +1,183 @@
+/*
+ * BRLTTY - A background process providing access to the console screen (when in
+ *          text mode) for a blind person using a refreshable braille display.
+ *
+ * Copyright (C) 1995-2026 by The BRLTTY Developers.
+ *
+ * BRLTTY comes with ABSOLUTELY NO WARRANTY.
+ *
+ * This is free software, placed under the terms of the
+ * GNU Lesser General Public License, as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at your option) any
+ * later version. Please see the file LICENSE-LGPL for details.
+ *
+ * Web Page: http://brltty.app/
+ *
+ * This software is maintained by Dave Mielke <dave@mielke.cc>.
+ */
+
+#include "prologue.h"
+
+#include <string.h>
+#include <wchar.h>
+
+#include "cmdline.h"
+#include "utf8.h"
+#include "unicode.h"
+
+BEGIN_COMMAND_LINE_OPTIONS(programOptions)
+END_COMMAND_LINE_OPTIONS(programOptions)
+
+BEGIN_COMMAND_LINE_PARAMETERS(programParameters)
+END_COMMAND_LINE_PARAMETERS(programParameters)
+
+BEGIN_COMMAND_LINE_NOTES(programNotes)
+END_COMMAND_LINE_NOTES
+
+BEGIN_COMMAND_LINE_DESCRIPTOR(programDescriptor)
+  .name = "utf8test",
+  .purpose = strtext("Test the incremental (streaming) UTF-8 decoder."),
+
+  .options = &programOptions,
+  .parameters = &programParameters,
+  .notes = COMMAND_LINE_NOTES(programNotes),
+END_COMMAND_LINE_DESCRIPTOR
+
+#define REPL UNICODE_REPLACEMENT_CHARACTER
+
+static unsigned int testsRun = 0;
+static unsigned int testsFailed = 0;
+
+/* Run a byte stream through the decoder, collecting every emitted character
+ * (both successfully decoded code points and replacement characters), honoring
+ * the reprocess protocol exactly as the terminal parser does.
+ */
+static unsigned int
+decodeBytes (const unsigned char *bytes, size_t count, wchar_t *out, unsigned int max) {
+  Utf8StreamDecoder decoder;
+  memset(&decoder, 0, sizeof(decoder));
+
+  unsigned int emitted = 0;
+  size_t index = 0;
+
+  while (index < count) {
+    wchar_t character;
+    int reprocess;
+    Utf8DecodeResult result = putUtf8StreamByte(&decoder, bytes[index], &character, &reprocess);
+
+    if (result == UTF8_DECODE_PENDING) {
+      index += 1;
+      continue;
+    }
+
+    if (emitted < max) out[emitted++] = character;
+
+    if ((result == UTF8_DECODE_INVALID) && reprocess) {
+      /* Feed the same byte again from a fresh state. */
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return emitted;
+}
+
+static void
+checkCase (
+  const char *name,
+  const unsigned char *bytes, size_t byteCount,
+  const wchar_t *expected, unsigned int expectedCount
+) {
+  wchar_t got[64];
+  testsRun += 1;
+
+  unsigned int gotCount = decodeBytes(bytes, byteCount, got, ARRAY_COUNT(got));
+  int ok = gotCount == expectedCount;
+
+  if (ok) {
+    for (unsigned int i=0; i<gotCount; i+=1) {
+      if (got[i] != expected[i]) {
+        ok = 0;
+        break;
+      }
+    }
+  }
+
+  if (ok) {
+    fprintf(stderr, "ok   %s\n", name);
+    return;
+  }
+
+  testsFailed += 1;
+  fprintf(stderr, "FAIL %s\n", name);
+
+  fprintf(stderr, "       got (%u):", gotCount);
+  for (unsigned int i=0; i<gotCount; i+=1) fprintf(stderr, " U+%04X", (unsigned int)got[i]);
+  fprintf(stderr, "\n");
+
+  fprintf(stderr, "  expected (%u):", expectedCount);
+  for (unsigned int i=0; i<expectedCount; i+=1) fprintf(stderr, " U+%04X", (unsigned int)expected[i]);
+  fprintf(stderr, "\n");
+}
+
+#define BYTES(...) ((const unsigned char []){__VA_ARGS__})
+#define CHARS(...) ((const wchar_t []){__VA_ARGS__})
+#define CHECK(name, bytes, chars) \
+  checkCase((name), (bytes), sizeof(bytes), (chars), ARRAY_COUNT(chars))
+
+static void
+runTests (void) {
+  /* plain ASCII */
+  CHECK("ascii letters", BYTES('H','i','!'), CHARS('H','i','!'));
+  CHECK("ascii control (tab)", BYTES(0X09), CHARS(0X09));
+
+  /* well-formed multi-byte sequences */
+  CHECK("2-byte e-acute", BYTES(0XC3,0XA9), CHARS(0X00E9));
+  CHECK("3-byte box hline", BYTES(0XE2,0X94,0X80), CHARS(0X2500));
+  CHECK("3-byte braille spinner", BYTES(0XE2,0XA0,0X8B), CHARS(0X280B));
+
+  /* Claude Code's rounded input-box corners and edge */
+  CHECK("rounded box top",
+    BYTES(0XE2,0X95,0XAD, 0XE2,0X94,0X80, 0XE2,0X95,0XAE),
+    CHARS(0X256D, 0X2500, 0X256E));
+
+  /* mixed ascii and multi-byte */
+  CHECK("mixed a-hline-b", BYTES('a', 0XE2,0X94,0X80, 'b'), CHARS('a', 0X2500, 'b'));
+
+#if WCHAR_MAX >= 0X10FFFF
+  CHECK("4-byte emoji", BYTES(0XF0,0X9F,0X98,0X80), CHARS(0X1F600));
+  CHECK("max code point", BYTES(0XF4,0X8F,0XBF,0XBF), CHARS(0X10FFFF));
+  CHECK("beyond unicode", BYTES(0XF4,0X90,0X80,0X80), CHARS(REPL));
+#endif /* WCHAR_MAX */
+
+  /* malformed input */
+  CHECK("lone continuation", BYTES(0X80), CHARS(REPL));
+  CHECK("invalid lead 0xFF", BYTES(0XFF), CHARS(REPL));
+  CHECK("invalid lead 0xF8", BYTES(0XF8), CHARS(REPL));
+
+  /* truncation: the partial sequence becomes U+FFFD and the interrupting
+   * byte is reprocessed as a fresh character */
+  CHECK("truncated then ascii", BYTES(0XE2,0X94,'X'), CHARS(REPL, 'X'));
+  CHECK("truncated then new lead",
+    BYTES(0XE2, 0XC3,0XA9), CHARS(REPL, 0X00E9));
+  CHECK("complete then stray continuation",
+    BYTES(0XC3,0XA9, 0XA9), CHARS(0X00E9, REPL));
+
+  /* overlong encodings must be rejected */
+  CHECK("overlong 2-byte slash", BYTES(0XC0,0XAF), CHARS(REPL));
+  CHECK("overlong 3-byte nul", BYTES(0XE0,0X80,0X80), CHARS(REPL));
+
+  /* surrogates are not valid UTF-8 */
+  CHECK("utf-16 surrogate", BYTES(0XED,0XA0,0X80), CHARS(REPL));
+}
+
+int
+main (int argc, char *argv[]) {
+  PROCESS_COMMAND_LINE(programDescriptor, argc, argv);
+
+  runTests();
+
+  fprintf(stderr, "\n%u test(s) run, %u failed\n", testsRun, testsFailed);
+  return testsFailed? PROG_EXIT_FATAL: PROG_EXIT_SUCCESS;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -2066,6 +2066,7 @@ AC_CONFIG_FILES([
    brltty.pc
    Documents/brltty.conf
    Documents/brltty.1
+   Documents/brltty-pty.1
    Documents/xbrlapi.1
    Documents/BrlAPIref.doxy
    Bindings/Emacs/add_directory.el

--- a/configure.ac
+++ b/configure.ac
@@ -1165,7 +1165,7 @@ BRLTTY_ARG_PACKAGE([system], [base system], [], [dnl
    darwin*)
       system_package="darwin"
       system_includes="-x objective-c"
-      system_libs="-framework IOKit -framework Foundation -framework CoreFoundation -lobjc"
+      system_libs="-framework IOKit -framework Foundation -framework CoreFoundation -framework AppKit -lobjc"
       ;;
    hpux*)
       if test -d /opt/audio/include


### PR DESCRIPTION
Closes part of #540. **Stacked on #545** (clipboard host bridge), which is itself stacked on #544 (pty-terminal-emulator). Only the single top commit (d6d145b) is new.

brltty-pty previously re-rendered the child's output through curses, which limited output to curses' 16-colour model and required BRLTTY to implement every terminal feature itself. This PR removes that path and replaces it with direct passthrough: the child's output goes straight to the outer terminal, which renders it at full fidelity.

**What this PR changes (one commit):**
- Remove the curses-based re-rendering path
- Pass child output through verbatim to the outer terminal (full true-colour, any SGR attributes, any terminal feature the outer terminal supports)
- Withhold sequences that must not reach the outer terminal: OSC 52 (handled by the clipboard layer) and CPR (cursor position reports, which would corrupt the outer terminal's state)
- ptypass end-to-end test (built by make tests): verifies that 24-bit SGR sequences reach the outer pty verbatim while OSC 52 and CPR are correctly withheld

**Why passthrough is the right default:** brltty-pty wraps exactly one program, not a multiplexed session. It does not need to composite multiple clients, so there is nothing to re-render — passing through is both simpler and more correct.

**Platform scope:** fully cross-platform.

**Draft:** base will be changed to the clipboard PR's base once #544 and #545 are merged.
