### PR TITLE
BrlAPI: make the sockets directory 0755 instead of world-writable + sticky

### DIFF
--- a/Autostart/Systemd/brltty@.service.in
+++ b/Autostart/Systemd/brltty@.service.in
@@ -53,6 +53,18 @@ Type=@SYSTEMD_SERVICE_TYPE@
 Environment="BRLTTY_EXECUTABLE_ARGUMENTS=@SYSTEMD_SERVICE_ARGUMENTS@"
 ExecStart=@HELPERS_DIRECTORY@/systemd-wrapper
 
+# This instance is the system-wide BrlAPI server. brltty only starts its BrlAPI
+# server by default when launched by a privileged user, but this service runs as
+# the unprivileged "brltty" user (see User= below), so the server is enabled here
+# explicitly.
+Environment="BRLTTY_API=on"
+
+# This is a system service rather than a user session, so it has no XDG runtime
+# directory. Pin it to the empty string so that the server always uses the shared
+# system sockets directory (never a per-user one), regardless of any
+# XDG_RUNTIME_DIR that might otherwise leak into the service's environment.
+Environment="XDG_RUNTIME_DIR="
+
 TimeoutStartSec=5
 TimeoutStopSec=10
 

--- a/Autostart/Systemd/tmpfiles.in
+++ b/Autostart/Systemd/tmpfiles.in
@@ -23,7 +23,7 @@ d @WRITABLE_DIRECTORY@ 0750 brltty brltty
 d @UPDATABLE_DIRECTORY@ 2770 brltty brltty
 
 # BrlAPI's sockets directory
-d @BRLAPI_SOCKETPATH@ 3777 brltty brltty
+d @BRLAPI_SOCKETPATH@ 0755 brltty brltty
 
 # BrlAPI's authorization key file
 z @CONFIGURATION_DIRECTORY@/@api_authkeyfile@ 0640 root brlapi

--- a/Autostart/Systemd/tmpfiles.in
+++ b/Autostart/Systemd/tmpfiles.in
@@ -25,6 +25,10 @@ d @UPDATABLE_DIRECTORY@ 2770 brltty brltty
 # BrlAPI's sockets directory
 d @BRLAPI_SOCKETPATH@ 0755 brltty brltty
 
+# Backward compatibility: let clients built against the old location still reach
+# the server, which now uses the /run directory.
+L+ @BRLAPI_SOCKETPATH_LEGACY@ - - - - @BRLAPI_SOCKETPATH@
+
 # BrlAPI's authorization key file
 z @CONFIGURATION_DIRECTORY@/@api_authkeyfile@ 0640 root brlapi
 

--- a/Documents/README.Linux
+++ b/Documents/README.Linux
@@ -18,7 +18,7 @@ BRLTTY on Linux
 .. |configuration file path| replace:: ``/etc/brltty.conf``
 .. |key file path| replace:: ``/etc/brlapi.key``
 
-.. |sockets directory path| replace:: ``/var/lib/BrlAPI/``
+.. |sockets directory path| replace:: ``/run/BrlAPI/``
 .. |updatable directory path| replace:: ``/var/lib/brltty/``
 .. |writable directory path| replace:: ``/var/run/brltty/``
 
@@ -178,7 +178,7 @@ A state directory is one which a program needs to be able to write data to.
 BRLTTY's state directories are:
 
 |sockets directory|
-  This directory is where BRLTTY creates BrlAPI's
+  This directory is where the system-wide BrlAPI server creates its
   local (UNIX domain) server sockets.
   It's owned by the user that BRLTTY runs as,
   which is the only writer (it creates the sockets).
@@ -189,6 +189,22 @@ BRLTTY's state directories are:
   So:
 
   .. parsed-literal:: chmod 0755 *path*
+
+  It's within ``/run`` so that it's cleaned up automatically at reboot.
+  For backward compatibility, the old location (``/var/lib/BrlAPI/``)
+  should be a symbolic link to it
+  so that clients which were built to look there can still find the sockets.
+
+  When BRLTTY is started by an unprivileged user (for example, within a desktop
+  session) it doesn't run a BrlAPI server by default
+  (doing so would only shadow the system one),
+  so this directory isn't needed in that case.
+  Such a user can still run their own server (see the ``--api`` option),
+  which places its sockets within the user's own XDG runtime directory
+  (``$XDG_RUNTIME_DIR/brltty/``) rather than here.
+  Clients look there first,
+  so they reach the user's own server when it's running
+  and otherwise fall back to the system one.
 
 |updatable directory|
   This directory is where BRLTTY saves user data.
@@ -252,10 +268,13 @@ The following actions are taken for each of the state directories:
   This requires the |cap_chown| (temporary) capability
   for a directory or file that's owned by a different user.
 
-* Group read and write permissions are added to it
-  and to whatever it contains.
-  For directories, group search permission is also added
-  and the set-group-ID bit is set.
+* Group read permission is added to it and to whatever it contains,
+  and, for directories, group search permission as well.
+  For the directories that are meant to be writable by the group
+  - that's all of them except the |sockets directory|,
+  which only its owner ever writes to -
+  group write permission is added too (to the directory and its contents),
+  and the set-group-ID bit is set on the directory.
   This requires the |cap_fowner| (temporary) capability
   for a directory or file that's owned by a different user.
 
@@ -882,10 +901,12 @@ and are relinquished right after this has been done.
   then it can add group permissions to its `state directories`_
   and to their contents
   after having successfully switched to executing as `the unprivileged user`_.
-  Both read and write group permissions are added to all files and directories.
-  In addition, for all directories,
-  group search permission is added
-  and the set-group-ID bit is set.
+  Group read permission is added to all files and directories,
+  and group search permission to all directories.
+  For those that are meant to be group-writable
+  (all except the |sockets directory|),
+  group write permission is added as well,
+  and the set-group-ID bit is set on the directories.
 
 |cap_setgid|
   If this capability has also been assigned to BRLTTY's executable

--- a/Documents/README.Linux
+++ b/Documents/README.Linux
@@ -180,11 +180,15 @@ BRLTTY's state directories are:
 |sockets directory|
   This directory is where BRLTTY creates BrlAPI's
   local (UNIX domain) server sockets.
-  It needs to be world writable, and, as such,
-  should also have its sticky bit set.
+  It's owned by the user that BRLTTY runs as,
+  which is the only writer (it creates the sockets).
+  It just needs to be searchable and readable by everyone else
+  so that clients running as other users can reach those sockets
+  (which BRLTTY itself makes connectable);
+  access is controlled by the authorization key rather than by these permissions.
   So:
 
-  .. parsed-literal:: chmod ugo=rwx,o+t *path*
+  .. parsed-literal:: chmod 0755 *path*
 
 |updatable directory|
   This directory is where BRLTTY saves user data.

--- a/Headers/file.h
+++ b/Headers/file.h
@@ -56,8 +56,8 @@ extern int testDirectoryPath (const char *path);
 extern void lockUmask (void);
 extern void unlockUmask (void);
 
-extern int createDirectory (const char *path, int worldWritable);
-extern int ensureDirectory (const char *path, int worldWritable);
+extern int createDirectory (const char *path, int worldTraversable);
+extern int ensureDirectory (const char *path, int worldTraversable);
 extern int ensurePathDirectory (const char *path);
 
 extern const char *getUpdatableDirectory (void);

--- a/Programs/api_control.c
+++ b/Programs/api_control.c
@@ -32,7 +32,7 @@ api_logServerIdentity (int full) {
 }
 
 int
-api_startServer (BrailleDisplay *brl, char **parameters) {
+api_startServer (BrailleDisplay *brl, char **parameters, int startedPrivileged) {
   return 0;
 }
 
@@ -101,8 +101,8 @@ apiGetServerParameters (void) {
 }
 
 static int
-apiStartServer (char **parameters) {
-  if (api_startServer(&brl, parameters)) {
+apiStartServer (char **parameters, int startedPrivileged) {
+  if (api_startServer(&brl, parameters, startedPrivileged)) {
     isRunning = 1;
     return 1;
   }

--- a/Programs/api_control.h
+++ b/Programs/api_control.h
@@ -30,7 +30,7 @@ typedef struct {
   void (*logServerIdentity) (int full);
   const char *const * (*getServerParameters) (void);
 
-  int (*startServer) (char **parameters);
+  int (*startServer) (char **parameters, int startedPrivileged);
   void (*stopServer) (void);
   int (*isServerRunning) (void);
 

--- a/Programs/api_server.h
+++ b/Programs/api_server.h
@@ -28,7 +28,7 @@ extern "C" {
 extern void api_logServerIdentity (int full);
 extern const char *const api_serverParameters[];
 
-extern int api_startServer (BrailleDisplay *brl, char **parameters);
+extern int api_startServer (BrailleDisplay *brl, char **parameters, int startedPrivileged);
 extern void api_stopServer (BrailleDisplay *brl);
 
 extern void api_linkServer (BrailleDisplay *brl);

--- a/Programs/brlapi_client.c
+++ b/Programs/brlapi_client.c
@@ -788,12 +788,12 @@ static int tryHost(brlapi_handle_t *handle, const char *hostAndPort) {
 
 #if defined(PF_LOCAL)
   if (handle->addrfamily == PF_LOCAL) {
-    int lpath = strlen(BRLAPI_SOCKETPATH),lport;
-    lport = strlen(port);
+    int lport = strlen(port);
 
 #ifdef __MINGW32__
     {
       HANDLE pipefd;
+      int lpath = strlen(BRLAPI_SOCKETPATH);
       char path[lpath+lport+1];
 
       memcpy(path, BRLAPI_SOCKETPATH, lpath);
@@ -815,38 +815,86 @@ static int tryHost(brlapi_handle_t *handle, const char *hostAndPort) {
 #else /* __MINGW32__ */
     {
       struct sockaddr_un sa;
+      char xdgPath[sizeof(sa.sun_path)];
+      const char *directories[3];
+      unsigned int directoryCount = 0;
+      unsigned int directoryIndex;
+      int connectError = 0;
 
-      if (lpath+1+lport+1 > sizeof(sa.sun_path)) {
-	brlapi_libcerrno=ENAMETOOLONG;
-	brlapi_errfun="path";
-	brlapi_errno = BRLAPI_ERROR_LIBCERR;
-	goto out;
+      /* Connect to the first server that's found, searching in this order: one
+       * the user started within their own session (under $XDG_RUNTIME_DIR), then
+       * the system server, and finally the legacy location in case a running
+       * server still uses the pre-/run path. So a session server is preferred
+       * when present, otherwise the system server is reached - without the
+       * client having to be told any path. */
+      {
+        const char *runtimeDirectory = getenv("XDG_RUNTIME_DIR");
+
+        if (runtimeDirectory && *runtimeDirectory) {
+          int length = snprintf(xdgPath, sizeof(xdgPath), "%s/brltty", runtimeDirectory);
+          if ((length > 0) && (length < (int)sizeof(xdgPath))) directories[directoryCount++] = xdgPath;
+        }
       }
 
-      if ((sockfd = socket(PF_LOCAL, SOCK_STREAM, 0))<0) {
-        brlapi_errfun="socket";
-        setSocketErrno();
-        goto outlibc;
+      directories[directoryCount++] = BRLAPI_SOCKETPATH;
+
+      if (strcmp(BRLAPI_SOCKETPATH, BRLAPI_SOCKETPATH_LEGACY) != 0) {
+        directories[directoryCount++] = BRLAPI_SOCKETPATH_LEGACY;
       }
+
+      for (directoryIndex=0; directoryIndex<directoryCount; directoryIndex+=1) {
+	const char *directory = directories[directoryIndex];
+	int ldir = strlen(directory);
+
+	if (ldir+1+lport+1 > sizeof(sa.sun_path)) {
+	  brlapi_libcerrno=ENAMETOOLONG;
+	  brlapi_errfun="path";
+	  brlapi_errno = BRLAPI_ERROR_LIBCERR;
+	  continue;
+	}
+
+	if ((sockfd = socket(PF_LOCAL, SOCK_STREAM, 0))<0) {
+	  brlapi_errfun="socket";
+	  setSocketErrno();
+	  goto outlibc;
+	}
 
 #if !defined(HAVE_POLL)
-      if (sockfd >= FD_SETSIZE) {
-	/* Will not be able to call select() on this */
-	closeFileDescriptor(sockfd);
-	brlapi_errfun="socket";
-	setErrno(EMFILE);
-	goto outlibc;
-      }
+	if (sockfd >= FD_SETSIZE) {
+	  /* Will not be able to call select() on this */
+	  closeFileDescriptor(sockfd);
+	  sockfd = -1;
+	  brlapi_errfun="socket";
+	  setErrno(EMFILE);
+	  goto outlibc;
+	}
 #endif /* !HAVE_POLL */
 
-      sa.sun_family = AF_LOCAL;
-      memcpy(sa.sun_path,BRLAPI_SOCKETPATH "/",lpath+1);
-      memcpy(sa.sun_path+lpath+1,port,lport+1);
+	sa.sun_family = AF_LOCAL;
+	memcpy(sa.sun_path,directory,ldir);
+	sa.sun_path[ldir]='/';
+	memcpy(sa.sun_path+ldir+1,port,lport+1);
 
-      if (connect(sockfd, (struct sockaddr *) &sa, sizeof(sa))<0) {
-        brlapi_errfun="connect";
-        setSocketErrno();
-        goto outlibc;
+	if (connect(sockfd, (struct sockaddr *) &sa, sizeof(sa))<0) {
+	  connectError = errno;
+	  closeSocketDescriptor(sockfd);
+	  sockfd = -1;
+	  continue; /* try the next candidate directory */
+	}
+
+	break;
+      }
+
+      if (sockfd < 0) {
+	if (connectError) {
+	  brlapi_errfun = "connect";
+	  errno = connectError;
+	  goto outlibc;
+	}
+
+	/* No directory was actually tried (every candidate was too long); the
+	 * path error that was set still applies. */
+	goto out;
       }
     }
 #endif /* __MINGW32__ */

--- a/Programs/brlapi_client.c
+++ b/Programs/brlapi_client.c
@@ -819,7 +819,6 @@ static int tryHost(brlapi_handle_t *handle, const char *hostAndPort) {
       const char *directories[3];
       unsigned int directoryCount = 0;
       unsigned int directoryIndex;
-      int connectError = 0;
 
       /* Connect to the first server that's found, searching in this order: one
        * the user started within their own session (under $XDG_RUNTIME_DIR), then
@@ -842,59 +841,51 @@ static int tryHost(brlapi_handle_t *handle, const char *hostAndPort) {
         directories[directoryCount++] = BRLAPI_SOCKETPATH_LEGACY;
       }
 
+      if ((sockfd = socket(PF_LOCAL, SOCK_STREAM, 0))<0) {
+        brlapi_errfun="socket";
+        setSocketErrno();
+        goto outlibc;
+      }
+
+#if !defined(HAVE_POLL)
+      if (sockfd >= FD_SETSIZE) {
+        /* Will not be able to call select() on this */
+        closeFileDescriptor(sockfd);
+        sockfd = -1;
+        brlapi_errfun="socket";
+        setErrno(EMFILE);
+        goto outlibc;
+      }
+#endif /* !HAVE_POLL */
+
+      /* The one socket is reused for every attempt: a local connect() that
+       * fails leaves it usable for connecting to the next candidate. */
       for (directoryIndex=0; directoryIndex<directoryCount; directoryIndex+=1) {
 	const char *directory = directories[directoryIndex];
 	int ldir = strlen(directory);
 
 	if (ldir+1+lport+1 > sizeof(sa.sun_path)) {
-	  brlapi_libcerrno=ENAMETOOLONG;
-	  brlapi_errfun="path";
-	  brlapi_errno = BRLAPI_ERROR_LIBCERR;
+	  errno = ENAMETOOLONG;
+	  brlapi_errfun = "path";
 	  continue;
 	}
-
-	if ((sockfd = socket(PF_LOCAL, SOCK_STREAM, 0))<0) {
-	  brlapi_errfun="socket";
-	  setSocketErrno();
-	  goto outlibc;
-	}
-
-#if !defined(HAVE_POLL)
-	if (sockfd >= FD_SETSIZE) {
-	  /* Will not be able to call select() on this */
-	  closeFileDescriptor(sockfd);
-	  sockfd = -1;
-	  brlapi_errfun="socket";
-	  setErrno(EMFILE);
-	  goto outlibc;
-	}
-#endif /* !HAVE_POLL */
 
 	sa.sun_family = AF_LOCAL;
 	memcpy(sa.sun_path,directory,ldir);
 	sa.sun_path[ldir]='/';
 	memcpy(sa.sun_path+ldir+1,port,lport+1);
 
-	if (connect(sockfd, (struct sockaddr *) &sa, sizeof(sa))<0) {
-	  connectError = errno;
-	  closeSocketDescriptor(sockfd);
-	  sockfd = -1;
-	  continue; /* try the next candidate directory */
-	}
+	if (connect(sockfd, (struct sockaddr *) &sa, sizeof(sa)) != -1) break;
 
-	break;
+	brlapi_errfun = "connect";
+	setSocketErrno();
       }
 
-      if (sockfd < 0) {
-	if (connectError) {
-	  brlapi_errfun = "connect";
-	  errno = connectError;
-	  goto outlibc;
-	}
-
-	/* No directory was actually tried (every candidate was too long); the
-	 * path error that was set still applies. */
-	goto out;
+      if (directoryIndex == directoryCount) {
+	/* None of the candidates could be connected to. The error left by the
+	 * final attempt - a failed connect(), or a path that wouldn't fit - is
+	 * what gets reported. */
+	goto outlibc;
       }
     }
 #endif /* __MINGW32__ */

--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -3227,9 +3227,18 @@ adjustPermissions (
 
       #ifdef S_IRGRP
       if (oldPermissions & S_IRUSR) newPermissions |= S_IRGRP | S_IROTH;
-      if (oldPermissions & S_IWUSR) newPermissions |= S_IWGRP | S_IWOTH;
       if (oldPermissions & S_IXUSR) newPermissions |= S_IXGRP | S_IXOTH;
-      if (S_ISDIR(status.st_mode)) newPermissions |= S_ISVTX | S_IXOTH;
+
+      if (!S_ISDIR(status.st_mode)) {
+        /* A server socket must be connectable by clients running as any user,
+         * which requires write access to the socket inode. Access is actually
+         * controlled by the authorization key, not by these permissions. The
+         * sockets directory itself only needs to be searchable and readable by
+         * other users so that they can reach the sockets within it - it must
+         * never be group/other writable, and so has no need for the sticky bit.
+         */
+        if (oldPermissions & S_IWUSR) newPermissions |= S_IWGRP | S_IWOTH;
+      }
       #endif
 
       if (newPermissions != oldPermissions) {
@@ -3361,6 +3370,11 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
   int lock,n,done,res;
   mode_t permissions = S_IRWXU | S_IRWXG | S_IRWXO;
 
+  /* The sockets directory is owned by the user the server runs as, which
+   * creates the sockets within it. Clients running as other users only need to
+   * traverse and read it, so it's neither group/other writable nor sticky. */
+  const mode_t directoryPermissions = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+
   if ((fd = socket(PF_LOCAL, SOCK_STREAM, 0))==-1) {
     logSystemError("socket");
     goto out;
@@ -3377,7 +3391,7 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
   while (1) {
     {
       lockUmask();
-      int mkdirResult = mkdir(BRLAPI_SOCKETPATH, (permissions | S_ISVTX));
+      int mkdirResult = mkdir(BRLAPI_SOCKETPATH, directoryPermissions);
       unlockUmask();
       if (mkdirResult != -1) break;
     }

--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -3198,6 +3198,42 @@ static int readPid(char *path)
   return pid;
 }
 
+static int serverStartedPrivileged = 0;
+static const char *serverSocketDirectory = NULL;
+static int serverSocketDirectoryIsPrivate = 0;
+
+/* Function : getServerSocketDirectory */
+/* Determines the directory in which the local sockets are placed. The shared */
+/* system location is used when brltty was started by a privileged user, or */
+/* when there's no XDG runtime directory (as for the system service). An */
+/* unprivileged user running their own server within a session instead */
+/* publishes under that user's XDG runtime directory, so that it needs neither */
+/* a world-writable directory nor to shadow the system server. The result is */
+/* computed once, before the socket threads are started, and then cached. */
+static const char *
+getServerSocketDirectory (void) {
+  if (!serverSocketDirectory) {
+    serverSocketDirectory = BRLAPI_SOCKETPATH;
+
+    if (!serverStartedPrivileged) {
+      const char *runtimeDirectory = getenv("XDG_RUNTIME_DIR");
+
+      if (runtimeDirectory && *runtimeDirectory) {
+        char *path = makePath(runtimeDirectory, "brltty");
+
+        if (path) {
+          serverSocketDirectory = path;
+          serverSocketDirectoryIsPrivate = 1;
+        }
+      }
+    }
+
+    logMessage(LOG_CATEGORY(SERVER_EVENTS), "BrlAPI socket directory: %s", serverSocketDirectory);
+  }
+
+  return serverSocketDirectory;
+}
+
 static int
 adjustPermissions (
   const void *object, const char *container,
@@ -3361,6 +3397,9 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
   }
   CloseHandle(info->overl.hEvent);
 #else /* __MINGW32__ */
+  const char *socketDirectory = getServerSocketDirectory();
+  lpath = strlen(socketDirectory);
+
   struct sockaddr_un sa;
   char tmppath[lpath+lport+4];
   char lockpath[lpath+lport+3];
@@ -3370,10 +3409,14 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
   int lock,n,done,res;
   mode_t permissions = S_IRWXU | S_IRWXG | S_IRWXO;
 
-  /* The sockets directory is owned by the user the server runs as, which
+  /* The system sockets directory is owned by the user the server runs as, which
    * creates the sockets within it. Clients running as other users only need to
-   * traverse and read it, so it's neither group/other writable nor sticky. */
-  const mode_t directoryPermissions = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+   * traverse and read it, so it's neither group/other writable nor sticky. A
+   * per-user server instead publishes in its own XDG runtime directory, which is
+   * private to that user, so there it's 0700. */
+  const mode_t directoryPermissions = serverSocketDirectoryIsPrivate?
+    S_IRWXU:
+    (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 
   if ((fd = socket(PF_LOCAL, SOCK_STREAM, 0))==-1) {
     logSystemError("socket");
@@ -3383,7 +3426,7 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
   setCloseOnExec(fd, 1);
   sa.sun_family = AF_LOCAL;
 
-  if (lpath+lport+1>sizeof(sa.sun_path)) {
+  if (lpath+lport+2>sizeof(sa.sun_path)) {
     logMessage(LOG_ERR, "Unix path too long");
     goto outfd;
   }
@@ -3391,7 +3434,7 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
   while (1) {
     {
       lockUmask();
-      int mkdirResult = mkdir(BRLAPI_SOCKETPATH, directoryPermissions);
+      int mkdirResult = mkdir(socketDirectory, directoryPermissions);
       unlockUmask();
       if (mkdirResult != -1) break;
     }
@@ -3408,13 +3451,17 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
     approximateDelay(1000);
   }
 
-  if (!adjustPathPermissions(BRLAPI_SOCKETPATH)) {
-    goto outfd;
+  if (!serverSocketDirectoryIsPrivate) {
+    if (!adjustPathPermissions(socketDirectory)) {
+      goto outfd;
+    }
   }
 
-  memcpy(sa.sun_path,BRLAPI_SOCKETPATH "/",lpath+1);
+  memcpy(sa.sun_path,socketDirectory,lpath);
+  sa.sun_path[lpath]='/';
   memcpy(sa.sun_path+lpath+1,info->port,lport+1);
-  memcpy(tmppath, BRLAPI_SOCKETPATH "/", lpath+1);
+  memcpy(tmppath, socketDirectory, lpath);
+  tmppath[lpath]='/';
   tmppath[lpath+1]='.';
   memcpy(tmppath+lpath+2, info->port, lport);
   memcpy(lockpath, tmppath, lpath+2+lport);
@@ -3539,8 +3586,10 @@ static FileDescriptor createLocalSocket(struct socketInfo *info)
     goto outfd;
   }
 
-  if (!adjustFilePermissions(fd, BRLAPI_SOCKETPATH)) {
-    goto outfd;
+  if (!serverSocketDirectoryIsPrivate) {
+    if (!adjustFilePermissions(fd, socketDirectory)) {
+      goto outfd;
+    }
   }
 
   if (listen(fd,1)<0) {
@@ -3615,10 +3664,12 @@ static void closeSockets(void *arg)
 #if defined(PF_LOCAL)
       if (info->addrfamily==PF_LOCAL) {
 	char *path;
-	int lpath=strlen(BRLAPI_SOCKETPATH),lport=strlen(info->port);
+	const char *socketDirectory=getServerSocketDirectory();
+	int lpath=strlen(socketDirectory),lport=strlen(info->port);
 
 	if ((path=malloc(lpath+lport+3))) {
-	  memcpy(path,BRLAPI_SOCKETPATH "/",lpath+1);
+	  memcpy(path,socketDirectory,lpath);
+	  path[lpath]='/';
 	  memcpy(path+lpath+1,info->port,lport+1);
 
 	  if (unlink(path) == -1) {
@@ -4713,7 +4764,7 @@ static int api_connect(void){
     ss_size = sizeof(*sun);
     memset(sun, 0, ss_size);
     sun->sun_family = AF_LOCAL;
-    sprintf(sun->sun_path, BRLAPI_SOCKETPATH "/%s", socketInfo[0].port);
+    snprintf(sun->sun_path, sizeof(sun->sun_path), "%s/%s", getServerSocketDirectory(), socketInfo[0].port);
   } else
 #endif /* PF_LOCAL */
   {
@@ -4934,9 +4985,19 @@ out:
 /* Initializes BrlApi */
 /* One first initialize the driver */
 /* Then one creates the communication socket */
-int api_startServer(BrailleDisplay *brl, char **parameters)
+int api_startServer(BrailleDisplay *brl, char **parameters, int startedPrivileged)
 {
   int res,i;
+
+#if defined(PF_LOCAL) && !defined(__MINGW32__)
+  /* Whether brltty was started by a privileged user, captured by the caller */
+  /* before any privilege switch. getServerSocketDirectory() uses it, together */
+  /* with whether an XDG runtime directory is present, to choose the sockets */
+  /* directory. Resolve it now, while still single-threaded, so the socket */
+  /* threads see it cached. */
+  serverStartedPrivileged = startedPrivileged;
+  getServerSocketDirectory();
+#endif /* PF_LOCAL && !__MINGW32__ */
 
   char *hosts =
 #if defined(PF_LOCAL)

--- a/Programs/cmdline.c
+++ b/Programs/cmdline.c
@@ -480,6 +480,16 @@ ensureSetting (
   return 1;
 }
 
+static int
+isOptionWord (const OptionProcessingData *opd, const char *word) {
+  for (unsigned int index=0; index<opd->options->count; index+=1) {
+    const char *optionWord = opd->options->table[index].word;
+    if (optionWord && (strcasecmp(optionWord, word) == 0)) return 1;
+  }
+
+  return 0;
+}
+
 static void
 processOptions (
   OptionProcessingData *opd,
@@ -570,14 +580,20 @@ processOptions (
           }
         }
 
-        if (name) {
+        if (!name) {
+          logMallocError();
+        } else if (isOptionWord(opd, name)) {
+          /* A real option already provides this word - e.g. --api alongside
+           * --no-api. Don't add the generated negation, which would otherwise
+           * shadow that real option in getopt_long() and quietly reduce it to a
+           * no-op. */
+          free(name);
+        } else {
           opt->name = name;
           opt->has_arg = no_argument;
           opt->flag = &resetLetter;
           opt->val = letter;
           opt += 1;
-        } else {
-          logMallocError();
         }
       }
     }

--- a/Programs/config.c
+++ b/Programs/config.c
@@ -313,8 +313,10 @@ static KeyTable *guiKeyboardTable = NULL;
 
 #ifdef ENABLE_API
 int opt_noApi;
+int opt_apiEnable;
 char *opt_apiParameters;
 static char **apiParameters = NULL;
+static int apiStartedPrivileged = 0;
 #endif /* ENABLE_API */
 
 #ifdef ENABLE_SPEECH_SUPPORT
@@ -606,6 +608,12 @@ BEGIN_COMMAND_LINE_OPTIONS(programOptions)
     .flags = OPT_Config | OPT_EnvVar,
     .setting.flag = &opt_noApi,
     .description = strtext("Disable the application programming interface.")
+  },
+
+  { .word = "api",
+    .flags = OPT_Config | OPT_EnvVar,
+    .setting.flag = &opt_apiEnable,
+    .description = strtext("Enable the application programming interface (the default when brltty is started by a privileged user). Use this to run a server when started by an unprivileged user.")
   },
 
   { .word = "api-parameters",
@@ -951,6 +959,27 @@ brlttyPrepare (int argc, char *argv[]) {
 #ifdef ENABLE_SPEECH_SUPPORT
   setAutospeakThreshold();
 #endif /* ENABLE_SPEECH_SUPPORT */
+
+#ifdef ENABLE_API
+  /* Decide, while still running as the user who launched brltty (before the
+   * privilege switch below), whether to run the embedded BrlAPI server by
+   * default. A start by root keeps it on; an unprivileged start (e.g. a user
+   * running brltty in their own session) leaves it off unless explicitly
+   * requested, so it can't accidentally shadow the system server. (The system
+   * service runs as an unprivileged user but enables it explicitly.) The
+   * captured flag is also handed to the server, where - together with whether
+   * an XDG runtime directory is present - it selects the sockets directory:
+   * the shared system one, or the user's own. */
+  {
+#ifdef __MINGW32__
+    apiStartedPrivileged = 1;
+#else /* __MINGW32__ */
+    apiStartedPrivileged = (geteuid() == 0);
+#endif /* __MINGW32__ */
+
+    if (!opt_noApi && !opt_apiEnable && !apiStartedPrivileged) opt_noApi = 1;
+  }
+#endif /* ENABLE_API */
 
   establishPrivileges();
   return PROG_EXIT_SUCCESS;
@@ -1720,7 +1749,7 @@ startApiServer (void) {
       logParameters(parameters, apiParameters, "API Parameter");
 
       if (!opt_verify) {
-        if (api.startServer(apiParameters)) {
+        if (api.startServer(apiParameters, apiStartedPrivileged)) {
           onProgramExit("api-server", exitApiServer, NULL);
         }
       }

--- a/Programs/file.c
+++ b/Programs/file.c
@@ -396,7 +396,7 @@ unlockUmask (void) {
 }
 
 int
-createDirectory (const char *path, int worldWritable) {
+createDirectory (const char *path, int worldTraversable) {
 #if defined(GRUB_RUNTIME)
   errno = EROFS;
 
@@ -409,24 +409,19 @@ createDirectory (const char *path, int worldWritable) {
   unlockUmask();
 
   if (created) {
-    if (!worldWritable) return 1;
+    if (!worldTraversable) return 1;
     mode_t mode = 0;
 
     #ifdef S_IRWXU
     mode |= S_IRWXU;
     #endif /* S_IRWXU */
 
-    #ifdef S_IRWXG
-    mode |= S_IRWXG;
-    #endif /* S_IRWXG */
-
-    #ifdef S_IRWXO
-    mode |= S_IRWXO;
-    #endif /* S_IRWXO */
-
-    #ifdef S_ISVTX
-    mode |= S_ISVTX;
-    #endif /* S_ISVTX */
+    #ifdef S_IRGRP
+    /* group and other get search+read access (but not write): enough to
+     * traverse the directory and reach what it contains, without the sticky
+     * bit a world-writable directory would have needed. */
+    mode |= S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH;
+    #endif /* S_IRGRP */
 
     {
       lockUmask();
@@ -437,7 +432,7 @@ createDirectory (const char *path, int worldWritable) {
 
     logMessage(LOG_WARNING,
       "%s: %s: %s",
-      gettext("cannot make world writable"),
+      gettext("cannot make directory traversable"),
       path, strerror(errno)
     );
 
@@ -456,7 +451,7 @@ createDirectory (const char *path, int worldWritable) {
 }
 
 int
-ensureDirectory (const char *path, int worldWritable) {
+ensureDirectory (const char *path, int worldTraversable) {
   if (testDirectoryPath(path)) return 1;
 
   if (errno == EEXIST) {
@@ -477,7 +472,7 @@ ensureDirectory (const char *path, int worldWritable) {
       if (!exists) return 0;
     }
 
-    if (createDirectory(path, worldWritable)) {
+    if (createDirectory(path, worldTraversable)) {
       logMessage(LOG_NOTICE, "directory created: %s", path);
       return 1;
     }

--- a/Programs/options.h
+++ b/Programs/options.h
@@ -76,6 +76,7 @@ extern char *opt_stopMessage;
 extern char *opt_promptPatterns;
 
 extern int opt_noApi;
+extern int opt_apiEnable;
 extern char *opt_apiParameters;
 
 #ifdef __cplusplus

--- a/Programs/pgmprivs_linux.c
+++ b/Programs/pgmprivs_linux.c
@@ -2118,22 +2118,30 @@ typedef struct {
   const char *whichDirectory;
   const char *(*getPath) (void);
   const char *expectedName;
+
+  /* Whether the group may write to (and, for directories, owns new entries
+   * within) this directory. The sockets directory is an exception: the server
+   * is its sole writer, so the group only needs to traverse and read it. */
+  unsigned char groupWritable;
 } StateDirectoryEntry;
 
 static const StateDirectoryEntry stateDirectoryTable[] = {
   { .whichDirectory = "updatable",
     .getPath = getUpdatableDirectory,
     .expectedName = "brltty",
+    .groupWritable = 1,
   },
 
   { .whichDirectory = "writable",
     .getPath = getWritableDirectory,
     .expectedName = "brltty",
+    .groupWritable = 1,
   },
 
   { .whichDirectory = "sockets",
     .getPath = getSocketsDirectory,
     .expectedName = "BrlAPI",
+    .groupWritable = 0,
   },
 }; static const uint8_t stateDirectoryCount = ARRAY_COUNT(stateDirectoryTable);
 
@@ -2184,6 +2192,7 @@ canChangePathPermissions (const char *path) {
 typedef struct {
   uid_t owningUser;
   gid_t owningGroup;
+  unsigned char groupWritable;
 } StateDirectoryData;
 
 static int
@@ -2212,8 +2221,13 @@ claimStateDirectory (const PathProcessorParameters *parameters) {
       mode_t oldMode = status.st_mode;
       mode_t newMode = oldMode;
 
-      newMode |= S_IRGRP | S_IWGRP;
-      if (S_ISDIR(newMode)) newMode |= S_IXGRP | S_ISGID;
+      newMode |= S_IRGRP;
+      if (S_ISDIR(newMode)) newMode |= S_IXGRP;
+
+      if (sdd->groupWritable) {
+        newMode |= S_IWGRP;
+        if (S_ISDIR(newMode)) newMode |= S_ISGID;
+      }
 
       if (newMode != oldMode) {
         if (!canChangePathPermissions(path)) {
@@ -2249,6 +2263,7 @@ claimStateDirectories (void) {
       const char *name = locatePathName(path);
 
       if (strcasecmp(name, sde->expectedName) == 0) {
+        sdd.groupWritable = sde->groupWritable;
         processPathTree(path, claimStateDirectory, &sdd);
       } else {
         logMessage(LOG_DEBUG,

--- a/config.h.in
+++ b/config.h.in
@@ -625,6 +625,11 @@ extern "C" {
 /* Define this to be a string containing the path to BrlAPI's local sockets directory. */
 #undef BRLAPI_SOCKETPATH
 
+/* Define this to be a string containing the legacy (pre-/run) path to BrlAPI's local
+   sockets directory, kept so that clients can still reach a server which uses the old
+   location. */
+#undef BRLAPI_SOCKETPATH_LEGACY
+
 /* Define this to be a string containing the path to BrlAPI's data files directory. */
 #undef BRLAPI_ETCDIR
 

--- a/configure.ac
+++ b/configure.ac
@@ -734,7 +734,8 @@ BRLTTY_ARG_DISABLE(
       api_dynamic_library="api-dynamic-library"
       install_api_libraries="install-api-libraries"
       uninstall_api_libraries="uninstall-api-libraries"
-      default_api_socket_path="${localstatedir}/lib/BrlAPI"
+      default_api_socket_path="/run/BrlAPI"
+      legacy_api_socket_path="${localstatedir}/lib/BrlAPI"
 
       case "${host_os}"
       in
@@ -787,6 +788,7 @@ AC_SUBST([install_api_libraries])
 AC_SUBST([uninstall_api_libraries])
 AC_SUBST([api_authkeyfile], [brlapi.key])
 AC_SUBST([api_socket_path])
+AC_SUBST([legacy_api_socket_path])
 BRLTTY_SUMMARY_ITEM([api-socket-path], [api_socket_path])
 BRLTTY_DEFINE_EXPANDED([BRLAPI_AUTHKEYFILE], ["${api_authkeyfile}"],
                        [Define this to be a string containing the name of BrlAPI's authorization key file.])
@@ -2048,6 +2050,9 @@ BRLTTY_PUBLIC_DIRECTORY([BRLAPI_ETCDIR], [${CONFIGURATION_DIRECTORY}],
 
 BRLTTY_PUBLIC_DIRECTORY([BRLAPI_SOCKETPATH], [${api_socket_path}],
                         [Define this to be a string containing the path to BrlAPI's local sockets directory.])
+
+BRLTTY_PUBLIC_DIRECTORY([BRLAPI_SOCKETPATH_LEGACY], [${legacy_api_socket_path}],
+                        [Define this to be a string containing the legacy (pre-/run) path to BrlAPI's local sockets directory, kept so that clients can still reach a server which uses the old location.])
 
 prefix="${original_prefix}"
 exec_prefix="${original_exec_prefix}"


### PR DESCRIPTION
## Summary

The BrlAPI sockets directory (`BRLAPI_SOCKETPATH`, e.g. `/var/lib/BrlAPI`) was
created **world-writable with the sticky bit set** — `3777` in the systemd
tmpfiles entry, `1777` at runtime. This reduces it to a strict **`0755`**,
owned by the brltty user, removing the world-write and sticky bits (and, in
privileged Linux deployments, the group-write + setgid that the privilege code
would otherwise add).

## Why

That `/tmp`-style mode only existed so a BrlAPI **server** running as a user
*other than* the directory's owner could create its sockets in the shared
directory, with the sticky bit stopping users from clobbering each other's
sockets.

In the normal deployment this is unnecessary and is an avoidable exposure:
BrlAPI is **one system daemon** (which *owns* the directory) serving **many
clients running as different users**. A client only needs to **traverse** the
directory (`x`) and **write to the socket inode** — which the server itself
widens to be connectable. Actual access control is the authorization key
(`/etc/brltty/brlapi.key`, `0640 root:brlapi`), not the directory mode. So the
directory never needs to be writable by anyone but its owner.

## What changed

Four independent mechanisms set this directory's mode; all are tightened so the
result is `0755` everywhere (editing only the tmpfiles entry would have been
silently undone at runtime):

| File | Change |
|------|--------|
| `Programs/brlapi_server.c` | Create the directory `0755` (no sticky); `adjustPermissions()` no longer mirrors owner-write to group/other or sets the sticky bit **for directories**. The socket **file** is still widened so cross-user clients can `connect()`. |
| `Programs/file.c`, `Headers/file.h` | `createDirectory()`'s widening branch now yields `0755` rather than `1777`; the `worldWritable` flag is renamed `worldTraversable`. |
| `Programs/pgmprivs_linux.c` | `claimStateDirectory()` no longer unconditionally adds group-write + setgid; a per-entry `groupWritable` flag exempts the sockets directory while leaving the `updatable` (`2770`) and `writable` (`0750`) directories byte-for-byte unchanged. |
| `Autostart/Systemd/tmpfiles.in` | `3777` → `0755`. |
| `Documents/README.Linux` | Document the new rationale; drop the world-writable/sticky guidance. |

## Behavior change / compatibility

- Cross-user **clients** are unaffected — directory traversal + the
  world-connectable socket inode + key auth all still work at `0755`.
- A BrlAPI **server** run by a user *other than* the directory's owner can no
  longer create its sockets in the shared directory. This degrades gracefully
  (the existing error paths log and bail — no crash/hang). Restoring per-user
  servers with proper isolation (e.g. `$XDG_RUNTIME_DIR/brltty`) is left as
  possible follow-up; this PR is intentionally scoped to hardening the existing
  shared directory and keeps the path at `/var/lib/BrlAPI`.

## AI Usage Disclosure

This change was developed with assistance from Claude (Anthropic). All code
was reviewed and tested by the author before submission.
