### PR TITLE
bluetooth_darwin: cancel the previous input monitor before creating a new one

### DIFF
--- a/Programs/bluetooth_darwin.c
+++ b/Programs/bluetooth_darwin.c
@@ -32,6 +32,7 @@
 #include "bluetooth_internal.h"
 #include "system_darwin.h"
 #include "async_io.h"
+#include "async_handle.h"
 
 @interface ServiceQueryResult: AsynchronousResult
 - (void) sdpQueryComplete
@@ -63,6 +64,14 @@ struct BluetoothConnectionExtensionStruct {
   RfcommChannelDelegate *rfcommDelegate;
 
   int inputPipe[2];
+
+  /* The handle returned by asyncMonitorFileInput() in bthMonitorInput()
+   * below, kept so it can be cancelled before inputPipe[0] is closed (see
+   * bthDestroyInputPipe()), and so a second registration can cancel a
+   * still-active previous one instead of orphaning it (see
+   * bthMonitorInput()) - matching bluetooth_android.c's own
+   * bthMonitorInput(), which already does both for the same reason. */
+  AsyncHandle inputMonitor;
 };
 
 static void
@@ -120,7 +129,19 @@ bthInitializeInputPipe (BluetoothConnectionExtension *bcx) {
 }
 
 static void
+bthCancelInputMonitor (BluetoothConnectionExtension *bcx) {
+  if (bcx->inputMonitor) {
+    asyncCancelRequest(bcx->inputMonitor);
+    bcx->inputMonitor = NULL;
+  }
+}
+
+static void
 bthDestroyInputPipe (BluetoothConnectionExtension *bcx) {
+  /* Must be cancelled before inputPipe[0] is closed below - see the
+   * inputMonitor field comment on BluetoothConnectionExtensionStruct. */
+  bthCancelInputMonitor(bcx);
+
   int *fileDescriptor = bcx->inputPipe;
   const int *end = fileDescriptor + ARRAY_COUNT(bcx->inputPipe);
 
@@ -257,7 +278,17 @@ bthDiscoverChannel (
 
 int
 bthMonitorInput (BluetoothConnection *connection, AsyncMonitorCallback *callback, void *data) {
-  return asyncMonitorFileInput(NULL, connection->extension->inputPipe[0], callback, data);
+  BluetoothConnectionExtension *bcx = connection->extension;
+
+  /* GIO deregisters by calling this again with callback == NULL (see
+   * gioDestroyHandleInputObject()) - matches bluetooth_android.c's own
+   * bthMonitorInput(). Without the early return, that call would register
+   * a fresh monitor with a NULL callback instead of just cancelling the
+   * real one, and the first invocation of that null callback would delete
+   * the operation out from under inputMonitor, leaving it dangling. */
+  bthCancelInputMonitor(bcx);
+  if (!callback) return 1;
+  return asyncMonitorFileInput(&bcx->inputMonitor, bcx->inputPipe[0], callback, data);
 }
 
 int


### PR DESCRIPTION
## What users get

A real bug fix: on macOS, once a Bluetooth-connected braille display's
connection closed (display powered off, moved out of range, or BRLTTY
exiting), BRLTTY could go into a permanent, full-CPU spin instead of shutting
down or reconnecting cleanly - logging `select error 9: Bad file descriptor`
on every iteration of its core event loop, indefinitely, until killed. This
could happen after any normal Bluetooth disconnect, not just an error case.

## What changed

`bthMonitorInput()` in `Programs/bluetooth_darwin.c` (added in #542) always
called `asyncMonitorFileInput()` unconditionally, discarding the returned
handle. Two problems, both present since #542:

1. **No way to cancel a stale registration.** `bluetooth_android.c`'s own
   `bthMonitorInput()` keeps its handle (`bcx->inputMonitor`) specifically so
   it can be cancelled before the underlying pipe is closed. Darwin's
   didn't - confirmed live, this caused a monitor to be left registered on an
   fd that had already been closed, which the core `select()`/`poll()` loop
   in `async_io.c` has no way to notice on its own and just spins forever
   reporting the same error.
2. **No `if (!callback) return 1;` guard.** GIO deregisters a monitor by
   calling this function again with `callback == NULL` (see
   `gioDestroyHandleInputObject()`). Without the guard, that call registered
   a *new* monitor with a `NULL` callback instead of cancelling the real one -
   the first time that null callback fired, `async_io.c` would delete the
   underlying operation out from under `bcx->inputMonitor`, leaving it
   dangling (a use-after-free risk on the next cancel attempt).

Both are fixed by mirroring `bluetooth_android.c`'s `bthMonitorInput()`
exactly: a shared `bthCancelInputMonitor()` helper is called both on
deregistration and at teardown (`bthDestroyInputPipe()`), and the early
return on a `NULL` callback - present in `bluetooth_android.c` from the
start, never added here - is added.

## Platform scope

macOS / IOBluetooth backend only (`Programs/bluetooth_darwin.c`). No other
platform's Bluetooth backend is touched.

## Testing / risk

Reproduced live: connect a Bluetooth braille display, let it exchange data
normally, then close the connection (unplug/power off the display, or exit
BRLTTY) - the process spins at 100% CPU indefinitely instead of exiting or
recovering. With this fix, verified clean, prompt shutdown (and clean
reconnect) across multiple repeated connect/disconnect cycles. The change is
small and copies an already-correct, already-shipped pattern from
`bluetooth_android.c`, so risk of a new regression is low.

## Reference

Fixes a regression introduced in #542 (`bluetooth_darwin: implement
bthMonitorInput using async_io`, merged). Found while testing the classic
Bluetooth connectivity fix (separate PR, stacked on top of this one) on real
hardware. Contributes to #558 - that issue needs both this PR and the
connectivity PR merged before it's fully fixed, so it isn't closed by this
PR alone.
