### PR TITLE
config: skip braille driver autodetection when one driver is already requested

### DIFF
--- a/Programs/config.c
+++ b/Programs/config.c
@@ -1751,9 +1751,15 @@ typedef struct {
 } DriverActivationData;
 
 static int
+wantAutodetection (const char *const *requestedDrivers) {
+  return requestedDrivers[0] && !requestedDrivers[1] &&
+         (strcmp(requestedDrivers[0], optionOperand_autodetect) == 0);
+}
+
+static int
 activateDriver (const DriverActivationData *data, int verify) {
   int oneDriver = data->requestedDrivers[0] && !data->requestedDrivers[1];
-  int autodetect = oneDriver && (strcmp(data->requestedDrivers[0], optionOperand_autodetect) == 0);
+  int autodetect = wantAutodetection(data->requestedDrivers);
   const char *const defaultDrivers[] = {data->getDefaultDriver(), NULL};
   const char *const *driver;
 
@@ -1993,6 +1999,17 @@ activateBrailleDriver (int verify) {
   int oneDevice = brailleDevices[0] && !brailleDevices[1];
   const char *const *device = (const char *const *)brailleDevices;
 
+  /* activateDriver() below only ever consults autodetectableDrivers when
+   * the caller hasn't already pinned down one specific, non-"auto" driver
+   * name - see wantAutodetection(), which this reuses. When a driver has
+   * been pinned down (e.g. "braille-driver fs" in the config, or -b fs on
+   * the command line - the common case for a device already known to the
+   * user), computing autodetectableDrivers for a Bluetooth candidate is
+   * pure waste: bthGetDriverCodes() pays a real, bounded network-timeout
+   * cost (BLUETOOTH_DEVICE_NAME_OBTAIN_TIMEOUT) to look up a device name
+   * that would just be thrown away. */
+  int needAutodetection = wantAutodetection((const char *const *)brailleDrivers);
+
   if (!oneDevice) verify = 0;
 
   while (*device) {
@@ -2020,7 +2037,9 @@ activateBrailleDriver (int verify) {
           }
 
           case GIO_TYPE_BLUETOOTH: {
-            if (!(autodetectableDrivers = bthGetDriverCodes(dev, BLUETOOTH_DEVICE_NAME_OBTAIN_TIMEOUT))) {
+            if (!needAutodetection) {
+              autodetectableDrivers = autodetectableBrailleDrivers_Bluetooth;
+            } else if (!(autodetectableDrivers = bthGetDriverCodes(dev, BLUETOOTH_DEVICE_NAME_OBTAIN_TIMEOUT))) {
               autodetectableDrivers = autodetectableBrailleDrivers_Bluetooth;
             }
 


### PR DESCRIPTION
## What users get

Slightly faster, more predictable braille-driver startup for anyone who
already names a specific driver (`braille-driver fs` in `brltty.conf`, or
`-b fs` on the command line - the common case once a display is known) and
has a Bluetooth candidate in their `braille-device` list. Most noticeable on
backends where a Bluetooth device-name lookup has a real, if bounded,
network-timeout cost (see the companion macOS Bluetooth PR).

## What changed

`activateBrailleDriver()` unconditionally computed `autodetectableDrivers`
for every candidate device, including calling `bthGetDriverCodes()` (a
Bluetooth device-name lookup) for Bluetooth candidates - even when
`activateDriver()`, later in the same call, was never actually going to
consult that value at all. `activateDriver()` only uses
`autodetectableDrivers` when the caller has requested exactly one driver
named `"auto"`; for any other request (a specific driver by name, or
several), it uses the requested driver list directly. A specific driver was
the common case this cost was being paid for nothing.

Fixed by adding a small shared `wantAutodetection()` predicate, used by both
`activateDriver()` (replacing its own inline computation, unchanged
behaviour) and `activateBrailleDriver()` (new: skip the Bluetooth name
lookup entirely when autodetection isn't wanted).

Deliberately not covered: `activateDriver()` also skips consulting
`autodetectableDrivers` when `getDefaultBrailleDriver()` returns non-null,
even with `braille-driver auto` requested. Mirroring that too would close
one more edge case, but it isn't the common "a specific driver is already
named" case this fix targets, and doing so cleanly would mean deferring
`autodetectableDrivers`'s computation entirely rather than precomputing it -
a larger change than this one. Left as a possible follow-up.

## Platform scope

Cross-platform (`Programs/config.c`). No platform-specific code touched.
Serial and USB autodetection are unaffected (their device-name lookups are
already fast, local enumeration - the fix doesn't need to apply there to be
worthwhile, though `wantAutodetection()` isn't platform-specific and
`activateDriver()` continues to use it for all three).

## Testing / risk

Verified via `braille-driver fs` (or `-b fs`) with a Bluetooth candidate in
`braille-device`: the name lookup and its "obtaining device name" log line
no longer appear before the real connection attempt. Autodetection itself
(`braille-driver auto`) is unaffected - `wantAutodetection()` is an exact
extraction of `activateDriver()`'s own existing condition, not a behaviour
change for that path. Low risk: the change only skips work that was already
provably unused for the case it skips it in.

## Reference

Found while diagnosing why a from-scratch Bluetooth connection attempt was
slower than necessary on macOS - see #561, which this is independent of but
was discovered alongside.
