### PR TITLE
brlapi_server: retry the full device list when a resume attempt fails

### DIFF
--- a/Programs/brlapi_server.c
+++ b/Programs/brlapi_server.c
@@ -409,6 +409,19 @@ static int resumeBrailleDriver(BrailleDisplay *brl) {
   if (trueBraille == &noBraille) return 0; /* core unlinked api */
   driverConstructing = 1;
   lockMutex(&apiSuspendMutex);
+
+  /* A resume attempt must be a genuine attempt, not one silently answered
+   * from a stale per-address connect-error cache entry left over from
+   * before the suspend (bthCloseConnection() never clears it) or from an
+   * earlier failed resume (nothing on this path ever calls it either).
+   * Without this, a single connect failure here - e.g. the still-unfixed
+   * IOBluetooth RFCOMM race documented in bluetooth_darwin.c - permanently
+   * short-circuits every later resume for this device: bthOpenConnection()
+   * would keep honoring the cached failure and never even try again. The
+   * normal cold-start path (startBrailleDriver(), config.c) already does
+   * this before every attempt; this path never did. */
+  forgetDevices();
+
   driverConstructed = constructBrailleDriver();
   if (driverConstructed) {
     disp = brl;
@@ -452,6 +465,23 @@ static int resumeDriver(void) {
 
   runCoreTask(apiCoreTask_resumeBrailleDriver, &rbd, 1);
   return rbd.resumed;
+}
+
+CORE_TASK_CALLBACK(apiCoreTask_restartBrailleDriver) {
+  /* Unlike resumeBrailleDriver(), this re-walks the full braille-device
+   * candidate list (see activateBrailleDriver() in config.c) instead of
+   * only ever retrying the single device that was active before suspend.
+   * Needed because a client that never gave up suspended mode properly may
+   * have left brltty pinned to a device (e.g. a Bluetooth display) that is
+   * no longer reachable, even though another candidate (e.g. USB) now is. */
+  restartBrailleDriver();
+}
+
+/* Function : restartDriver */
+/* Requests a full driver restart, trying every configured braille device
+ * again from scratch - not just the one device resumeDriver() would retry. */
+static void restartDriver(void) {
+  runCoreTask(apiCoreTask_restartBrailleDriver, NULL, 1);
 }
 
 /* Function : resetBrailleDriver */
@@ -1472,7 +1502,15 @@ static int handleResumeDriver(Connection *c, brlapi_packetType_t type, brlapi_pa
   lockMutex(&apiRawMutex);
   suspendConnection = NULL;
   unlockMutex(&apiRawMutex);
-  resumeDriver();
+  if (!resumeDriver()) {
+    /* This is the normal handoff-resume path (e.g. brltty-handoff resume),
+     * not just the improper-disconnect safety net below - it used to
+     * discard failure here entirely, leaving the driver stuck unconstructed
+     * with nothing ever retrying. Fall back to a full restart so the normal
+     * retry-until-success loop takes over, same as the safety net does. */
+    logMessage(LOG_WARNING, "Couldn't resume braille driver - restarting it instead");
+    restartDriver();
+  }
   writeAck(c->fd);
   return 0;
 }
@@ -2830,8 +2868,16 @@ static int processRequest(Connection *c, PacketHandlers *handlers)
       suspendConnection = NULL;
       unlockMutex(&apiRawMutex);
       logMessage(LOG_WARNING,"Client on fd %"PRIfd" did not give up suspended mode properly",c->fd);
-      if (!resumeDriver())
-	logMessage(LOG_WARNING,"Couldn't resume braille driver");
+      if (!resumeDriver()) {
+	/* resumeDriver() only retries the single device that was active
+	 * before suspend. If that device is no longer reachable (e.g. a
+	 * Bluetooth display that dropped its link while suspended), fall
+	 * back to a full restart so other configured devices (e.g. USB)
+	 * get a chance too, instead of leaving the driver stuck retrying
+	 * only the stale device. */
+	logMessage(LOG_WARNING,"Couldn't resume braille driver - restarting it instead");
+	restartDriver();
+      }
     }
     if (c->tty) {
       logMessage(LOG_CATEGORY(SERVER_EVENTS), "client on fd %"PRIfd" did not give up control of tty %#010x properly",c->fd,c->tty->number);


### PR DESCRIPTION
## Summary

When a BrlAPI client resumes a suspended braille driver, a failed resume attempt could leave the driver stuck permanently unconstructed, with nothing ever retrying - and a stale per-address connect-error cache could silently keep it that way even after the underlying device becomes reachable again.

## What changed

Two related gaps in the resume path (`Programs/brlapi_server.c`):

1. `resumeBrailleDriver()` reconnects only to the single device that was active before suspend, via `constructBrailleDriver()` directly - unlike a normal cold start (`startBrailleDriver()`, `config.c`), which walks the full configured device list. If that one device is unreachable when resume happens, there's no fallback to any other configured device.

2. Both callers of this resume path - `handleResumeDriver()` (the normal `RESUMEDRIVER` packet handler) and the safety net for a client that disconnects without resuming cleanly - previously discarded a failed resume entirely. Confirmed live: this leaves the driver stuck unconstructed indefinitely after a single failed attempt, since resume isn't on any retry timer the way a cold start is.

Compounding both: `resumeBrailleDriver()` never called `forgetDevices()` before attempting, so a per-address connect-error cache entry left over from before the suspend (or from an earlier failed resume on this same path) can silently short-circuit the very next real attempt too, without even trying. Normal cold starts always clear this cache first; this path never did.

Fixed by having `resumeBrailleDriver()` forget devices before attempting (so a resume is always a genuine attempt), and by falling back to a full `restartBrailleDriver()` - which retries the complete configured device list - whenever the narrow resume attempt fails, on both call sites.

## Platform scope

Cross-platform (`Programs/brlapi_server.c`, `Programs/config.c` untouched, no header changes). Not specific to any one driver or backend - applies to any setup using BrlAPI's suspend/resume mechanism (e.g. handing a display over to another consumer temporarily and back).

## Testing / risk

Found and reproduced on macOS, in a setup that suspends/resumes BRLTTY's Bluetooth connection to hand a display to the OS's own accessibility braille support and back. Confirmed live: after this fix, a failed resume attempt now recovers automatically within a few seconds via the fallback, instead of leaving the driver stuck indefinitely - watched this happen multiple times across a testing session. The fallback path (`restartDriver()`) reuses the exact core-task/mutex pattern the existing resume path already used, so no new locking discipline is introduced; verified it doesn't deadlock by exercising it live repeatedly.

## Reference

Found while testing macOS Bluetooth reconnection reliability - part of the broader effort tracked in #540.
