### PR TITLE
FreedomScientific: retry the extended-keys config packet if it's not acknowledged

### DIFF
--- a/Drivers/Braille/FreedomScientific/braille.c
+++ b/Drivers/Braille/FreedomScientific/braille.c
@@ -260,6 +260,7 @@ struct BrailleDataStruct {
   AsyncHandle missingAcknowledgementAlarm;
 
   unsigned char configFlags;
+  unsigned char configAttemptsRemaining;
   int firmnessSetting;
 
   int outputPayloadLimit;
@@ -378,8 +379,29 @@ logNegativeAcknowledgement (const FS_Packet *packet) {
              packet->header.arg2, component);
 }
 
+/* How many times to resend the FS_PKT_CONFIG packet (the one that turns on
+ * extended keys, FS_CFG_EXTKEY - needed for the rocker/navigation keys,
+ * which arrive as a separate packet type from panning/routing/output) if it
+ * is NAK'd or its acknowledgement never arrives. Previously this was a
+ * single, never-retried attempt: one lost or NAK'd packet - plausible right
+ * after a Bluetooth reconnect, before the link has fully settled, the same
+ * class of timing issue that motivated bumping the identity-probe timeout
+ * elsewhere in this file - silently and permanently disabled extended keys
+ * for the rest of that connection, with every other key and cell output
+ * working normally. Bounded so a display that genuinely keeps NAKing (e.g.
+ * a real, non-transient incompatibility) still gives up eventually rather
+ * than retrying forever. */
+#define FS_CONFIG_ACKNOWLEDGEMENT_ATTEMPTS 3
+
 static void
 handleConfigAcknowledgement (BrailleDisplay *brl, int ok) {
+  if (!ok && (--brl->data->configAttemptsRemaining > 0)) {
+    unsigned char left = brl->data->configAttemptsRemaining;
+    logMessage(LOG_WARNING, "config packet not acknowledged - retrying (%u %s left)",
+               left, (left == 1)? "attempt": "attempts");
+    return;
+  }
+
   brl->data->configFlags = 0;
 }
 
@@ -769,6 +791,7 @@ setModel (BrailleDisplay *brl, const char *modelName, const char *firmware) {
     brl->data->acknowledgementHandler = NULL;
     brl->data->missingAcknowledgementAlarm = NULL;
     brl->data->configFlags = 0;
+    brl->data->configAttemptsRemaining = FS_CONFIG_ACKNOWLEDGEMENT_ATTEMPTS;
     brl->data->firmnessSetting = -1;
 
     if (brl->data->model->type == MOD_TYPE_Focus) {


### PR DESCRIPTION
## Summary

On Freedom Scientific Focus displays (firmware 3+), the rocker/navigation keys can silently stop working for the rest of a connection - while panning, routing keys, and cell output all keep working normally - if a single startup configuration packet is lost or not acknowledged.

## What changed

These displays report their rocker/navigation keys exclusively via a separate packet type (`FS_PKT_EXTKEY`) that the display only starts sending after the host sends one `FS_PKT_CONFIG` packet with `FS_CFG_EXTKEY` set, at connect time. Panning, routing, dot keys, and cell output all use other packet types entirely and are unaffected by this handshake.

`handleConfigAcknowledgement()` unconditionally cleared the pending config state on both a real NAK and a missing-acknowledgement timeout, with no retry: a single lost or NAK'd `CONFIG` packet silently and permanently disabled extended keys for the rest of that connection. This makes the symptom (pan left/right work, up/down navigation dead) easy to mistake for a key-table problem rather than a connect-time handshake one.

A single lost startup packet is plausible right when a connection has just been (re)established and the link hasn't fully settled - the same class of timing sensitivity that already motivated giving this driver's own identity-probe a longer timeout elsewhere in this file.

Fixed by retrying the `CONFIG` packet up to a bounded number of times before giving up, reusing the same acknowledgement/alarm mechanism this file already uses for every other request/ack exchange - each retry is paced by the existing 500ms missing-ACK alarm rather than a tight loop, so the bounded worst case is a small, fixed extra delay, not a busy retry.

## Platform scope

Driver-level (`Drivers/Braille/FreedomScientific/braille.c`), not platform-specific. The failure was observed over Bluetooth on macOS, but the mechanism (a single unacknowledged startup packet) isn't tied to any one transport or OS.

## Testing / risk

The underlying failure was observed once, in real use: rocker up/down stopped responding mid-session after a Bluetooth reconnect, with panning and routing unaffected, resolved by a fresh `brl_construct()`. This fix is based on tracing the exact packet flow to its root cause (confirmed by reading the code, including verifying the alarm-cancellation ordering guarantees a fresh timeout window on each retry attempt), not on reproducing and re-confirming the failure a second time with the fix in place - flagging that honestly rather than overstating verification. Risk is low: the change is additive (a bounded retry loop reusing existing infrastructure), and a display that never NAKs behaves identically to before.

## Reference

Found while testing macOS Bluetooth reconnection reliability - part of the broader effort tracked in #540.
