### PR TITLE
Darwin: declare user activity on braille key input, to stop macOS sleeping mid-session

### DIFF
--- a/Headers/system.h
+++ b/Headers/system.h
@@ -25,6 +25,18 @@ extern "C" {
 
 extern void initializeSystemObject (void);
 
+/* Tell the OS that the user just did something, so that its idle/display
+ * sleep timers get reset the same way they would for a real keypress or
+ * mouse move. Braille input never goes through the OS's normal HID input
+ * path (BRLTTY talks to the display directly over USB or Bluetooth), so
+ * without this, the OS has no way to know the user is active and can sleep
+ * the machine mid-session. Call this on every braille key command that
+ * reaches the core, not just on some of them - it's meant to be called
+ * that often (see notifyUserActivity() in system_darwin.c). A no-op on
+ * platforms where the OS already sees this activity some other way, or
+ * where nothing has been implemented for this yet. */
+extern void notifyUserActivity (void);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/Programs/brl_input.c
+++ b/Programs/brl_input.c
@@ -31,6 +31,7 @@
 #include "cmd_enqueue.h"
 #include "io_generic.h"
 #include "core.h"
+#include "system.h"
 
 static int
 processInput (void) {
@@ -49,6 +50,12 @@ processInput (void) {
 
   setBrailleOnline(&brl);
   if (command == EOF) return 0;
+
+  /* A real command from the user's own key press - tell the OS the user is
+   * active (see notifyUserActivity()'s comment for why this is needed at
+   * all: braille input bypasses the OS's normal HID activity tracking). */
+  notifyUserActivity();
+
   enqueueCommand(command);
   return 1;
 }

--- a/Programs/system_darwin.c
+++ b/Programs/system_darwin.c
@@ -20,6 +20,7 @@
 
 #include <errno.h>
 #include <IOKit/IOKitLib.h>
+#include <IOKit/pwr_mgt/IOPMLib.h>
 
 #import <Foundation/NSLock.h>
 #import <Foundation/NSThread.h>
@@ -168,6 +169,37 @@ setDarwinSystemError (IOReturn result) {
 
 void
 initializeSystemObject (void) {
+}
+
+void
+notifyUserActivity (void) {
+  /* Reported live: the machine can go to sleep mid-session while braille
+   * keys are actively being pressed (seen with a Focus 40 over Bluetooth
+   * RFCOMM; the same reasoning applies to USB). BRLTTY reads its keys
+   * directly off the raw USB/Bluetooth connection, never through
+   * IOHIDSystem, so macOS's idle/display sleep timers have no way to see
+   * braille input as user activity.
+   *
+   * IOPMAssertionDeclareUserActivity is IOKit's documented mechanism for
+   * exactly this: a non-HID input source telling power management that a
+   * real user action just happened, so the display/idle sleep timers get
+   * reset the same way a real keypress would reset them. Unlike an
+   * IOPMAssertionCreate*-style standing assertion, it does not hold sleep
+   * off indefinitely - it only nudges the existing timers - so it's safe to
+   * call on every single braille key command with no risk of preventing a
+   * legitimate idle sleep once input actually stops. The assertion ID it
+   * hands back only matters if you want to report continuous activity
+   * under the same ID; a fresh call each time (ID discarded) is fine here
+   * since calls already coincide with discrete key events. */
+  IOPMAssertionID assertionID;
+
+  IOReturn result = IOPMAssertionDeclareUserActivity(
+    CFSTR("BRLTTY: braille key input"), kIOPMUserActiveLocal, &assertionID
+  );
+
+  if (result != kIOReturnSuccess) {
+    logMessage(LOG_WARNING, "IOPMAssertionDeclareUserActivity failed: 0X%X", result);
+  }
 }
 
 @interface AsynchronousResult ()

--- a/Programs/system_java.c
+++ b/Programs/system_java.c
@@ -488,3 +488,7 @@ initializeSystemObject (void) {
   initializeAndroidEnvironment(getJavaNativeInterface());
 #endif /* platform-speciofic initialization */
 }
+
+void
+notifyUserActivity (void) {
+}

--- a/Programs/system_linux.c
+++ b/Programs/system_linux.c
@@ -1467,3 +1467,7 @@ destroyInputEventMonitor (InputEventMonitor *monitor) {
 void
 initializeSystemObject (void) {
 }
+
+void
+notifyUserActivity (void) {
+}

--- a/Programs/system_msdos.c
+++ b/Programs/system_msdos.c
@@ -387,3 +387,7 @@ snprintf (char *str, size_t size, const char *format, ...) {
 void
 initializeSystemObject (void) {
 }
+
+void
+notifyUserActivity (void) {
+}

--- a/Programs/system_none.c
+++ b/Programs/system_none.c
@@ -23,3 +23,7 @@
 void
 initializeSystemObject (void) {
 }
+
+void
+notifyUserActivity (void) {
+}

--- a/Programs/system_windows.c
+++ b/Programs/system_windows.c
@@ -203,6 +203,10 @@ initializeSystemObject (void) {
   loadLibraries();
 }
 
+void
+notifyUserActivity (void) {
+}
+
 #ifdef __MINGW32__
 #include "win_errno.h"
 


### PR DESCRIPTION
## Problem

macOS goes to sleep mid-session while braille keys are actively being
pressed - confirmed live with a Focus 40 connected over Bluetooth RFCOMM,
and typing on the braille keyboard steadily. The same reasoning applies to
a USB-connected display: either way, BRLTTY talks to the display directly
over the raw connection, never through the OS's HID input path, so macOS's
idle and display sleep timers have no way to see braille input as user
activity.

## Fix

Add a small platform hook, `notifyUserActivity()`, called once per real
braille key command in `brl_input.c`'s `processInput()` - the existing
choke point that already distinguishes an actual command from a poll with
nothing new to report, regardless of which braille driver or connection
type (USB/Bluetooth/serial) produced it.

On Darwin, this calls `IOPMAssertionDeclareUserActivity()`, which is
IOKit's documented API for exactly this situation: a non-HID input source
telling the power management subsystem that real user activity just
happened, so the OS resets its idle/display sleep timers the same way a
real keypress would. It's explicitly *not* a standing sleep-prevention
assertion (unlike `IOPMAssertionCreate*`/`caffeinate`-style APIs) - it only
nudges the existing timers - so calling it on every keystroke can't
prevent a legitimate idle sleep once input actually stops.

Every other platform gets a no-op stub, following the same per-platform
pattern already used for `initializeSystemObject()` in `system.h`, so this
is easy to extend to other platforms later (e.g. Linux desktop environments
have an analogous "user is idle" problem for non-HID input) without
touching the cross-platform call site.

## Verification

- Builds clean on macOS (`macos/integration`, the branch actually deployed
  daily): `Headers/system.h`, `Programs/brl_input.c`, `Programs/system_darwin.c`,
  and `Programs/system_none.c` all compile without warnings on this machine.
- `Programs/system_linux.c`, `system_windows.c`, `system_msdos.c`,
  `system_java.c` each get the same trivial no-op stub already used by
  `initializeSystemObject()` in that file - syntactically guaranteed correct,
  not independently cross-compiled (no toolchain for those platforms here).
- Not yet soak-tested against an actual full idle-sleep timeout (that takes
  as long as the configured timeout to observe); the mechanism itself
  (`IOPMAssertionDeclareUserActivity`) is Apple's documented, stable API for
  this exact use case, already used for the same purpose by other
  non-HID-input macOS apps.
